### PR TITLE
feat: core ticket lifecycle CRUD with CLI, search, and API

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -1,316 +1,358 @@
-# Implementation Plan: Core Ticket Lifecycle CRUD
+# vtic Implementation Plan: Core Ticket Lifecycle CRUD (v0.1 MVP)
 
-## Scope
+> Generated: 2026-04-09
+> Branch: feat/ticket-lifecycle-core
+> Scope: CLI-based ticket CRUD with markdown file storage and BM25 search.
 
-Implement the P0 Core Ticket Lifecycle for `vtic` with markdown-backed storage and CLI support:
+---
 
-- `init`
-- `create`
-- `get`
-- `list`
-- `update`
-- `delete`
+## 1. Project Structure
 
-Include:
-
-- project/package structure
-- data models for CRUD
-- markdown read/write format
-- BM25 keyword search strategy
-- implementation order with dependencies
-- test plan
-
-Out of scope for this phase:
-
-- semantic search
-- advanced status workflow validation
-- bulk operations
-- HTTP API expansion beyond what CRUD implementation naturally enables
-- restore/trash management beyond what delete architecture needs
-
-## Design Principles
-
-- Local-first, zero-infrastructure storage
-- Markdown files as source of truth
-- Strong validation at model boundaries
-- Deterministic file layout and serialization
-- Atomic writes to avoid corruption
-- Clear separation between CLI, models, storage, and search
-- Search index is derived data and rebuildable from markdown files
-
-## Project Structure
-
-### `pyproject.toml`
-
-Use a standard `src/` layout and expose a `vtic` CLI entrypoint.
-
-Required pieces:
-
-- `project.name = "vtic"`
-- `requires-python = ">=3.11"`
-- dependencies:
-  - `pydantic>=2.0`
-  - `typer>=0.9`
-  - `rich>=13.0`
-  - `pyyaml>=6.0`
-- optional search dependency:
-  - either no extra dependency if using built-in BM25
-  - or optional `rank-bm25` / `zvec` if chosen
-- dev dependencies:
-  - `pytest`
-  - `pytest-cov`
-
-CLI entrypoint:
-
-- `vtic = "vtic.cli.main:app"`
-
-### Package Layout
-
-Recommended package structure:
-
-- `src/vtic/__init__.py`
-  - version and package metadata
-- `src/vtic/constants.py`
-  - category prefixes, default paths, frontmatter markers
-- `src/vtic/errors.py`
-  - domain-specific exceptions
-- `src/vtic/utils.py`
-  - `slugify`, UTC timestamp helpers, repo parsing, tag normalization
-- `src/vtic/models.py`
-  - enums and Pydantic models
-- `src/vtic/storage.py`
-  - markdown file persistence and CRUD
-- `src/vtic/search.py`
-  - BM25 indexing and querying
-- `src/vtic/config.py`
-  - load/resolve ticket directory config
-- `src/vtic/cli/__init__.py`
-- `src/vtic/cli/main.py`
-  - Typer app and command handlers
-
-Tests:
-
-- `tests/test_models.py`
-- `tests/test_storage.py`
-- `tests/test_cli.py`
-- `tests/test_search.py`
-- `tests/test_integration.py`
-
-## File List With Purpose
-
-### Core application files
-
-- `pyproject.toml`
-  - packaging, dependencies, CLI script registration
-- `README.md`
-  - user-facing behavior reference
-- `src/vtic/models.py`
-  - canonical shape of ticket data and CRUD payloads
-- `src/vtic/constants.py`
-  - stable category-to-prefix mapping and markdown section markers
-- `src/vtic/errors.py`
-  - `TicketNotFoundError`, `TicketWriteError`, `ValidationError`, etc.
-- `src/vtic/utils.py`
-  - helpers reused by storage, CLI, and search
-- `src/vtic/storage.py`
-  - create/get/list/update/delete against markdown files
-- `src/vtic/search.py`
-  - full-text indexing over ticket content and metadata
-- `src/vtic/config.py`
-  - resolve tickets directory from config/defaults
-- `src/vtic/cli/main.py`
-  - user command surface
-
-### Test files
-
-- `tests/conftest.py`
-  - shared fixtures, temp directories, CLI runner helpers
-- `tests/test_models.py`
-  - model validation and normalization
-- `tests/test_storage.py`
-  - markdown serialization, file paths, atomic CRUD behavior
-- `tests/test_cli.py`
-  - command parsing, output, exit behavior
-- `tests/test_search.py`
-  - indexing and query ranking
-- `tests/test_integration.py`
-  - end-to-end lifecycle coverage
-
-## Data Models
-
-## Enums
-
-Implement as `StrEnum` in Python 3.11+.
-
-### `Severity`
-
-Values:
-
-- `critical`
-- `high`
-- `medium`
-- `low`
-
-### `Status`
-
-Values:
-
-- `open`
-- `in_progress`
-- `blocked`
-- `fixed`
-- `wont_fix`
-- `closed`
-
-### `Category`
-
-Use the taxonomy from `DATA_MODELS.md`:
-
-- `security`
-- `auth`
-- `code_quality`
-- `performance`
-- `frontend`
-- `testing`
-- `documentation`
-- `infrastructure`
-- `configuration`
-- `api`
-- `data`
-- `ui`
-- `dependencies`
-- `build`
-- `other`
-
-### Category prefix mapping
-
-Use `CATEGORY_PREFIXES` as the source for ID generation:
-
-- `security -> S`
-- `auth -> A`
-- `code_quality -> C`
-- `performance -> P`
-- `frontend -> F`
-- `testing -> T`
-- `documentation -> D`
-- `infrastructure -> I`
-- `configuration -> N`
-- `api -> X`
-- `data -> M`
-- `ui -> U`
-- `dependencies -> Y`
-- `build -> B`
-- `other -> O`
-
-## `Ticket` dataclass/model
-
-Use a validated Pydantic model for persistence and API/CLI interchange.
-
-Fields:
-
-- `id: str`
-- `title: str`
-- `description: str | None`
-- `fix: str | None`
-- `repo: str`
-- `owner: str | None`
-- `category: Category`
-- `severity: Severity`
-- `status: Status`
-- `file: str | None`
-- `tags: list[str]`
-- `created_at: datetime`
-- `updated_at: datetime`
-- `slug: str`
-
-Derived helpers:
-
-- `filename -> "{id}-{slug}.md"`
-- `filepath -> "{owner}/{repo_name}/{category}/{id}-{slug}.md"`
-- `search_text -> concatenated text for indexing`
-
-Validation rules:
-
-- `id` matches `^[A-Z]\d+$`
-- `title` non-empty after stripping
-- `repo` matches `owner/repo`
-- `tags` normalized to lowercase and deduplicated
-- `updated_at >= created_at`
-- `slug` is lowercase kebab-case
-
-## `TicketCreate`
-
-Fields:
-
-- required:
-  - `title`
-  - `repo`
-- optional:
-  - `description`
-  - `fix`
-  - `owner`
-  - `category` default `code_quality`
-  - `severity` default `medium`
-  - `status` default `open`
-  - `file`
-  - `tags`
-
-Behavior:
-
-- no `id`, `slug`, or timestamps accepted from normal CLI create path
-- normalize title, repo, owner, tags
-- derive owner from `repo` if omitted
-
-## `TicketUpdate`
-
-Partial update model. All fields optional:
-
-- `title`
-- `description`
-- `fix`
-- `owner`
-- `category`
-- `severity`
-- `status`
-- `file`
-- `tags`
-
-Behavior:
-
-- `exclude_unset=True` for patch semantics
-- if `title` changes, regenerate `slug`
-- always refresh `updated_at`
-- do not allow direct edits to `id`, `repo`, `created_at`, `slug`
-
-## Markdown File Format
-
-## Directory layout
-
-Source of truth is the markdown tree:
-
-```text
-tickets/
-└── {owner}/
-    └── {repo}/
-        └── {category}/
-            └── {id}-{slug}.md
+```
+vtic/
+├── pyproject.toml
+├── README.md
+├── LICENSE
+├── src/
+│   └── vtic/
+│       ├── __init__.py
+│       ├── models.py
+│       ├── config.py
+│       ├── errors.py
+│       ├── constants.py
+│       ├── utils.py
+│       ├── id_gen.py
+│       ├── store.py
+│       ├── ticket.py
+│       ├── search.py
+│       └── cli/
+│           ├── __init__.py
+│           └── main.py
+└── tests/
+    ├── __init__.py
+    ├── conftest.py
+    ├── test_models.py
+    ├── test_config.py
+    ├── test_errors.py
+    ├── test_id_gen.py
+    ├── test_store.py
+    ├── test_ticket.py
+    ├── test_search.py
+    └── test_cli.py
 ```
 
-Example:
+### pyproject.toml
 
-```text
-tickets/
-└── ejacklab/
-    └── open-dsearch/
-        └── security/
-            └── S1-cors-wildcard-in-production.md
+```toml
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "vtic"
+version = "0.1.0"
+description = "Lightweight, local-first ticket system with markdown-backed storage"
+readme = "README.md"
+license = "MIT"
+requires-python = ">=3.11"
+dependencies = [
+    "pydantic>=2.0",
+    "typer>=0.12",
+    "rich>=13.0",
+    "pyyaml>=6.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+    "pytest-cov>=5.0",
+]
+
+[project.scripts]
+vtic = "vtic.cli.main:app"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+markers = [
+    "integration: marks tests as integration tests (deselect with '-m \"not integration\"')",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/vtic"]
 ```
 
-## Frontmatter format
+---
 
-Use YAML frontmatter plus explicit body markers:
+## 2. File List
 
-```md
+| File | Description |
+|------|-------------|
+| `src/vtic/__init__.py` | Package exports: `__version__`, key classes |
+| `src/vtic/models.py` | All Pydantic models: enums (`Severity`, `Status`, `Category`), `Ticket`, `TicketCreate`, `TicketUpdate`, `TicketResponse`, `SearchFilters`, `SearchResult`, `SearchResponse` |
+| `src/vtic/config.py` | `VticConfig`, `TicketsConfig`, `ServerConfig`, `SearchConfig`. TOML loading with `tomllib`. Env var overrides (`VTIC_TICKETS_DIR`, etc.). `load_config()`, `get_config()` singleton. |
+| `src/vtic/errors.py` | `VticError` base + all subclasses: `TicketNotFoundError`, `TicketAlreadyExistsError`, `ValidationError`, `ConfigError`, `TicketWriteError`, `TicketReadError` |
+| `src/vtic/constants.py` | `CATEGORY_PREFIXES` dict, `VALID_STATUSES` list, `TERMINAL_STATUSES` list, `STATUS_METADATA` dict |
+| `src/vtic/utils.py` | `slugify(text: str) -> str`, `utcnow() -> datetime`, `iso_format(dt: datetime) -> str` |
+| `src/vtic/id_gen.py` | `generate_ticket_id(category: Category, existing_ids: set[str]) -> str` |
+| `src/vtic/store.py` | `TicketStore` class — markdown file CRUD: `get()`, `save()`, `delete()`, `move_to_trash()`, `list()`, `exists()`, `list_ids()`. YAML frontmatter parse/write. Atomic file writes. |
+| `src/vtic/ticket.py` | `TicketService` class — orchestration: `create()`, `get()`, `update()`, `delete()`, `list()`. Coordinates ID generation, timestamps, store persistence, and index updates. |
+| `src/vtic/search.py` | `BM25Search` class — pure-Python BM25 implementation: `index_ticket()`, `remove_ticket()`, `search()`, `rebuild()`. Tokenizer, scoring, result ranking. |
+| `src/vtic/cli/__init__.py` | CLI package init |
+| `src/vtic/cli/main.py` | Typer app with commands: `init`, `create`, `get`, `list`, `update`, `delete`, `search`. Rich-formatted output. |
+| `tests/conftest.py` | Shared fixtures: `tmp_ticket_dir` (ticket store on tmp_path), `sample_ticket`, `store` (populated TicketStore), `cli_runner` (Typer CliRunner) |
+| `tests/test_models.py` | Enum values, Ticket validation (ID format, repo format, tags, timestamps), TicketCreate defaults, TicketUpdate partial fields |
+| `tests/test_config.py` | TOML loading, env var overrides, defaults, invalid config |
+| `tests/test_errors.py` | Error construction, error_code/message/status_code, `to_response()` method |
+| `tests/test_id_gen.py` | Sequential IDs, gap filling, unknown categories, empty set, concurrent safety |
+| `tests/test_store.py` | File roundtrip (write → read), atomic writes, frontmatter parsing, directory structure, trash operations, list filtering, exists check |
+| `tests/test_ticket.py` | `TicketService.create()` (auto ID, timestamps, validation), `get()`, `update()` (partial, timestamp refresh, immutable fields), `delete()` (soft/hard) |
+| `tests/test_search.py` | BM25 scoring (exact match > partial), filtering, empty results, special characters, reindex |
+| `tests/test_cli.py` | All commands via `CliRunner`: init, create, get, list, update, delete, search. Exit codes, output formats |
+
+---
+
+## 3. Implementation Order (Dependency Graph)
+
+```
+Phase 1: Foundation (no dependencies)
+  ├── constants.py     # Pure data, no deps
+  ├── errors.py        # Only depends on models (for ErrorDetail) — but define ErrorDetail inline
+  ├── utils.py         # Pure functions, no deps
+  └── models.py        # Depends on: nothing external (pydantic only)
+
+Phase 2: Core Services (depends on Phase 1)
+  ├── id_gen.py        # Depends on: constants.py (CATEGORY_PREFIXES)
+  ├── config.py        # Depends on: models.py (for config model types)
+  └── store.py         # Depends on: models.py, errors.py, utils.py, config.py
+
+Phase 3: Orchestration (depends on Phase 2)
+  ├── ticket.py        # Depends on: store.py, id_gen.py, models.py, errors.py, utils.py
+  └── search.py        # Depends on: models.py, store.py (for ticket text)
+
+Phase 4: CLI (depends on Phase 3)
+  └── cli/main.py      # Depends on: ticket.py, search.py, config.py, models.py, errors.py
+
+Phase 5: Tests (parallel with development, final pass)
+  └── tests/*.py       # Test each module in Phase order
+```
+
+### Implementation Sequence (Single Dev)
+
+1. `pyproject.toml` — project metadata, dependencies
+2. `src/vtic/__init__.py` — version string
+3. `src/vtic/constants.py` — prefixes, statuses, metadata
+4. `src/vtic/utils.py` — slugify, utcnow
+5. `src/vtic/errors.py` — error hierarchy
+6. `src/vtic/models.py` — all Pydantic models (largest file)
+7. `src/vtic/config.py` — TOML + env loading
+8. `src/vtic/id_gen.py` — ID generation
+9. `src/vtic/store.py` — markdown file I/O
+10. `src/vtic/ticket.py` — CRUD orchestration
+11. `src/vtic/search.py` — BM25 search
+12. `src/vtic/cli/__init__.py` + `src/vtic/cli/main.py` — CLI
+13. `tests/conftest.py` — shared fixtures
+14. `tests/test_*.py` — all test files
+15. Verify: `python -m pytest tests/ -v`
+
+---
+
+## 4. Data Models (`src/vtic/models.py`)
+
+### Enums
+
+```python
+from enum import StrEnum
+
+class Severity(StrEnum):
+    CRITICAL = "critical"
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+
+class Status(StrEnum):
+    OPEN = "open"
+    IN_PROGRESS = "in_progress"
+    BLOCKED = "blocked"
+    FIXED = "fixed"
+    WONT_FIX = "wont_fix"
+    CLOSED = "closed"
+
+class Category(StrEnum):
+    SECURITY = "security"
+    AUTH = "auth"
+    CODE_QUALITY = "code_quality"
+    PERFORMANCE = "performance"
+    FRONTEND = "frontend"
+    TESTING = "testing"
+    DOCUMENTATION = "documentation"
+    INFRASTRUCTURE = "infrastructure"
+    CONFIGURATION = "configuration"
+    API = "api"
+    DATA = "data"
+    UI = "ui"
+    DEPENDENCIES = "dependencies"
+    BUILD = "build"
+    OTHER = "other"
+```
+
+### VticBaseModel
+
+```python
+from pydantic import BaseModel, ConfigDict
+
+class VticBaseModel(BaseModel):
+    model_config = ConfigDict(
+        populate_by_name=True,
+        str_strip_whitespace=True,
+        validate_assignment=True,
+        extra="ignore",
+    )
+```
+
+### Ticket
+
+```python
+class Ticket(VticBaseModel):
+    # Identity
+    id: str = Field(..., min_length=1, max_length=20, pattern=r"^[A-Z]\d+$")
+    
+    # Content
+    title: str = Field(..., min_length=1, max_length=200)
+    description: Optional[str] = Field(default=None, max_length=50000)
+    fix: Optional[str] = Field(default=None, max_length=20000)
+    
+    # Metadata
+    repo: str = Field(..., min_length=3, max_length=100, pattern=r"^[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+$")
+    owner: Optional[str] = Field(default=None, max_length=100)
+    category: Category = Field(default=Category.CODE_QUALITY)
+    severity: Severity = Field(default=Severity.MEDIUM)
+    status: Status = Field(default=Status.OPEN)
+    
+    # References
+    file: Optional[str] = Field(default=None, max_length=500, pattern=r"^[^:]+(:\d+(-\d+)?)?$")
+    tags: list[str] = Field(default_factory=list)
+    
+    # Timestamps
+    created_at: datetime = Field(...)
+    updated_at: datetime = Field(...)
+    
+    # Derived
+    slug: str = Field(..., min_length=1, max_length=100, pattern=r"^[a-z0-9-]+$")
+    
+    # Validators (from DATA_MODELS.md):
+    # - validate_id_format: regex match, .upper()
+    # - validate_title_not_empty: strip check
+    # - validate_repo_format: owner/repo check, .lower()
+    # - normalize_tags: lowercase, strip, dedup, max 50
+    # - validate_timestamps: updated_at >= created_at
+    
+    @property
+    def is_terminal(self) -> bool: ...
+    @property
+    def filename(self) -> str: ...  # "{id}-{slug}.md"
+    @property
+    def filepath(self) -> str: ...  # "{repo}/{category}/{filename}"
+    @property
+    def search_text(self) -> str: ...  # "title description fix tags..."
+```
+
+### TicketCreate
+
+```python
+class TicketCreate(VticBaseModel):
+    """Request body for creating a ticket. Required: title, repo."""
+    title: str = Field(..., min_length=1, max_length=200)
+    repo: str = Field(..., min_length=3, max_length=100, pattern=r"^[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+$")
+    description: Optional[str] = Field(default=None, max_length=50000)
+    fix: Optional[str] = Field(default=None, max_length=20000)
+    owner: Optional[str] = Field(default=None, max_length=100)
+    category: Category = Field(default=Category.CODE_QUALITY)
+    severity: Severity = Field(default=Severity.MEDIUM)
+    status: Status = Field(default=Status.OPEN)
+    file: Optional[str] = Field(default=None, max_length=500)
+    tags: list[str] = Field(default_factory=list)
+```
+
+### TicketUpdate
+
+```python
+class TicketUpdate(VticBaseModel):
+    """Partial update. All fields optional. extra='forbid'."""
+    title: Optional[str] = Field(default=None, min_length=1, max_length=200)
+    description: Optional[str] = Field(default=None, max_length=50000)
+    fix: Optional[str] = Field(default=None, max_length=20000)
+    owner: Optional[str] = Field(default=None, max_length=100)
+    category: Optional[Category] = Field(default=None)
+    severity: Optional[Severity] = Field(default=None)
+    status: Optional[Status] = Field(default=None)
+    file: Optional[str] = Field(default=None, max_length=500)
+    tags: Optional[list[str]] = Field(default=None)
+    # NOTE: id, created_at, repo are IMMUTABLE — not included here
+```
+
+### TicketResponse (CLI/API serialization)
+
+```python
+class TicketResponse(VticBaseModel):
+    """Serializable ticket for CLI/API output. All enum values as strings."""
+    id: str
+    title: str
+    description: Optional[str] = None
+    fix: Optional[str] = None
+    repo: str
+    owner: Optional[str] = None
+    category: str  # Category.value
+    severity: str  # Severity.value
+    status: str    # Status.value
+    file: Optional[str] = None
+    tags: list[str] = Field(default_factory=list)
+    created_at: str  # ISO 8601
+    updated_at: str  # ISO 8601
+    slug: str
+    is_terminal: bool
+    filename: str
+    filepath: str
+
+    @classmethod
+    def from_ticket(cls, ticket: Ticket) -> "TicketResponse": ...
+```
+
+### Search Models (minimal for v0.1)
+
+```python
+class SearchFilters(VticBaseModel):
+    severity: Optional[list[Severity]] = None
+    status: Optional[list[Status]] = None
+    repo: Optional[list[str]] = None  # supports glob patterns
+    category: Optional[list[Category]] = None
+    tags: Optional[list[str]] = None  # AND matching
+
+class SearchResult(VticBaseModel):
+    id: str
+    title: str
+    repo: str
+    category: str
+    severity: str
+    status: str
+    score: float = Field(ge=0.0)
+    highlights: list[str] = Field(default_factory=list)
+
+class SearchResponse(VticBaseModel):
+    results: list[SearchResult] = Field(default_factory=list)
+    total: int = Field(ge=0)
+    query: str
+    limit: int = Field(ge=1)
+    offset: int = Field(ge=0)
+    has_more: bool
+```
+
+---
+
+## 5. Markdown File Format (`src/vtic/store.py`)
+
+### Ticket File Format
+
+```markdown
 ---
 id: S1
 title: CORS Wildcard in Production
@@ -334,453 +376,1044 @@ All FastAPI services use allow_origins=['*'] which enables CSRF attacks.
 Use ALLOWED_ORIGINS from environment variable.
 ```
 
-## Read behavior
-
-Storage parser should:
-
-- require opening and closing frontmatter delimiters
-- parse YAML into a dict
-- coerce enums and timestamps via `Ticket`
-- parse description/fix from markers
-- tolerate empty body sections
-- derive `slug` from filename, not frontmatter
-- reject malformed files with a domain-specific read error
-
-## Write behavior
-
-Serializer should:
-
-- emit stable field order
-- always write timestamps in UTC ISO 8601 with `Z`
-- always emit `<!-- DESCRIPTION -->`
-- emit `<!-- FIX -->` only when fix content exists
-- ensure trailing newline
-- use atomic write:
-  - write temp file in same directory
-  - `os.replace` into final path
-
-## CLI Commands
-
-Implement in `src/vtic/cli/main.py` using Typer.
-
-## `vtic init`
-
-Purpose:
-
-- create the tickets base directory
-- create search metadata directory if needed later
-
-Behavior:
-
-- `vtic init --dir ./tickets`
-- idempotent
-- success message on creation/existing directory
-
-## `vtic create`
-
-Arguments/options:
-
-- `--repo`
-- `--title`
-- `--description`
-- `--fix`
-- `--owner`
-- `--category`
-- `--severity`
-- `--status`
-- `--file`
-- `--tags`
-- `--dir`
-
-Behavior:
-
-- validate through `TicketCreate`
-- derive owner from repo if omitted
-- generate next category-prefixed ID
-- generate slug from title
-- set `created_at` and `updated_at`
-- persist markdown file
-- return rendered ticket
-
-Dependencies:
-
-- models
-- utils
-- storage
-
-## `vtic get`
-
-Arguments/options:
-
-- positional `ticket_id`
-- `--format table|json|markdown`
-- `--dir`
-
-Behavior:
-
-- lookup by case-insensitive ID
-- render normalized ticket or raw markdown
-- exit non-zero if not found
-
-Dependencies:
-
-- storage
-
-## `vtic list`
-
-Arguments/options:
-
-- `--repo`
-- `--owner`
-- `--category`
-- `--severity`
-- `--status`
-- `--tags`
-- `--created-after`
-- `--created-before`
-- `--updated-after`
-- `--updated-before`
-- `--sort`
-- `--format`
-- `--dir`
-
-Behavior:
-
-- load tickets from markdown files
-- apply structured filters
-- sort by `severity`, `status`, `created_at`, `updated_at`, or `title`
-- default sort by ID
-
-Dependencies:
-
-- models
-- storage
-
-## `vtic update`
-
-Arguments/options:
-
-- `--id`
-- any mutable field from `TicketUpdate`
-- `--dir`
-
-Behavior:
-
-- read existing ticket
-- merge patch data
-- if title/category changes, move file path accordingly
-- update `updated_at`
-- rewrite markdown atomically
-- return updated ticket
-
-Dependencies:
-
-- models
-- storage
-- utils
-
-## `vtic delete`
-
-Arguments/options:
-
-- `--id`
-- `--yes`
-- `--force` if hard delete is supported in this phase
-- `--dir`
-
-Core CRUD behavior:
-
-- remove ticket file from source tree
-- require confirmation unless `--yes`
-- return success/failure status
-
-Recommendation:
-
-- implement hard delete first for strict CRUD scope
-- leave soft delete/trash as a follow-up if scope must stay narrow
-
-Dependencies:
-
-- storage
-
-## Storage Layer Responsibilities
-
-Implement `TicketStore` in `src/vtic/storage.py`.
-
-Public methods:
-
-- `create_ticket(...) -> Ticket`
-- `get(ticket_id: str) -> Ticket`
-- `list(filters: SearchFilters | None = None, sort_by: str | None = None) -> list[Ticket]`
-- `update(ticket_id: str, updates: TicketUpdate) -> Ticket`
-- `delete(ticket_id: str) -> None`
-- `count() -> int`
-
-Private helpers:
-
-- `_next_id(category: Category) -> str`
-- `_find_ticket_path(ticket_id: str) -> Path`
-- `_read_ticket(path: Path) -> Ticket`
-- `_serialize_ticket(ticket: Ticket) -> str`
-- `_write_ticket(ticket: Ticket, path: Path) -> None`
-- `_split_frontmatter(raw: str) -> tuple[str, str]`
-- `_parse_frontmatter(frontmatter: str) -> dict[str, object]`
-- `_parse_body(body: str) -> tuple[str | None, str | None]`
-- `_sort_tickets(...)`
-- `_matches_filters(...)`
-
-Important decisions:
-
-- ID allocation should be serialized with a lock file if concurrent writers are in scope
-- file path should be derived from ticket fields, never manually supplied
-- update must handle file move when title/category changes
-- malformed markdown files should not crash `list`; they should either:
-  - be skipped with collected errors, or
-  - fail fast in strict mode
-
-## BM25 Search Plan
-
-This CRUD plan should leave search ready, even if search is not the main deliverable.
-
-## Preferred approach
-
-Implement a built-in BM25 scorer first.
-
-Reasons:
-
-- no external service required
-- fully aligned with local-first design
-- sufficient for P0 keyword search
-- simpler test surface than `zvec`
-
-## `zvec` integration option
-
-If `zvec` is required later:
-
-- keep search behind a `TicketSearch` interface
-- make the index derived from `ticket.search_text`
-- store index metadata under a hidden path inside tickets dir, for example:
-  - `.vtic-search-index.json`
-  - or `.vtic/` if multiple index artifacts are added later
-
-Recommendation for this phase:
-
-- ship built-in BM25 as default
-- optionally add `zvec` behind a feature flag or adapter later
-- do not couple CRUD completion to `zvec`
-
-## Index content
-
-Index these fields:
-
-- `id`
-- `title`
-- `description`
-- `fix`
-- `file`
-- `tags`
-
-Boost strategy:
-
-- title highest
-- id and file medium
-- description/fix normal
-- tags medium
-
-Simple implementation choices:
-
-- tokenize on non-alphanumeric boundaries
-- lowercase normalization
-- discard empty tokens
-- keep index rebuildable from markdown source
-
-## Search lifecycle hooks
-
-- `create`: index new ticket
-- `update`: refresh ticket entry
-- `delete`: remove ticket entry
-- `reindex`: rebuild from all markdown files
-
-For initial phase, rebuilding on demand is acceptable if persistence is not required yet.
-
-## Implementation Order With Dependencies
-
-## Phase 1: Foundation
-
-1. Finalize `pyproject.toml`
-2. Finalize package layout under `src/vtic`
-3. Add constants and error types
-4. Add utility functions
-
-Dependencies:
-- none
-
-## Phase 2: Models
-
-1. Implement enums
-2. Implement `Ticket`
-3. Implement `TicketCreate`
-4. Implement `TicketUpdate`
-5. Implement filter models used by list/search
-
-Dependencies:
-- Phase 1
-
-## Phase 3: Markdown storage
-
-1. Define canonical file path derivation
-2. Implement frontmatter/body parser
-3. Implement serializer
-4. Implement atomic write helper
-5. Implement `create_ticket`
-6. Implement `get`
-7. Implement `list`
-8. Implement `update`
-9. Implement `delete`
-
-Dependencies:
-- Phase 2
-
-## Phase 4: CLI CRUD
-
-1. Implement `init`
-2. Implement `create`
-3. Implement `get`
-4. Implement `list`
-5. Implement `update`
-6. Implement `delete`
-7. Standardize exit codes and error output
-
-Dependencies:
-- Phase 3
-
-## Phase 5: BM25 search
-
-1. Implement tokenizer
-2. Implement in-memory BM25 scorer
-3. Add index build/rebuild flow
-4. Add storage-to-search hooks
-5. Add `search` command if desired in same milestone
-
-Dependencies:
-- Phase 3
-
-## Phase 6: Hardening
-
-1. concurrency lock for ID generation
-2. malformed file handling in list/search
-3. deterministic sorting
-4. CLI JSON output modes
-5. reindex command
-6. documentation refresh
-
-Dependencies:
-- Phases 4 and 5
-
-## Dependency Notes
-
-- CLI cannot be finalized before storage API is stable
-- search depends on `Ticket.search_text` and storage iteration
-- update depends on path recalculation rules from `Ticket`
-- delete can be implemented before search, but search cleanup hooks should follow immediately after
-
-## Test Plan
-
-## Model tests
-
-`tests/test_models.py`
-
-Cover:
-
-- enum values
-- repo validation
-- title normalization
-- tag normalization and deduplication
-- timestamp ordering
-- `TicketCreate` defaults
-- `TicketUpdate` partial semantics
-- invalid IDs and slugs
-
-## Storage tests
-
-`tests/test_storage.py`
-
-Cover:
-
-- create minimal ticket
-- create full ticket
-- generated file path matches expected owner/repo/category/id-slug layout
-- generated markdown matches canonical format
-- read ticket from markdown
-- update title regenerates slug and moves file
-- update category moves directory
-- update only touches specified fields
-- delete removes file
-- get missing ticket raises not found
-- list returns all tickets
-- list filters by repo/category/severity/status/tags/date
-- sort behavior
-- malformed frontmatter handling
-- malformed body marker handling
-- atomic write behavior where practical
-
-## CLI tests
-
-`tests/test_cli.py`
-
-Cover:
-
-- `init` creates directory
-- `create` with required args
-- `create` with all args
-- `get` success and not found
-- `list` empty and populated output
-- `update` changes specific fields
-- `delete --yes` removes ticket
-- validation failures return non-zero
-- JSON output for `get` and `list` if included
-
-## Search tests
-
-`tests/test_search.py`
-
-Cover:
-
-- tokenization
-- exact match on title
-- search on description
-- search on tags/file/id
-- result ordering by score
-- filters applied after/before scoring as designed
-- update refreshes searchable content
-- delete removes searchable content
-- rebuild from markdown corpus
-
-## Integration tests
-
-`tests/test_integration.py`
-
-End-to-end flow:
-
-1. `init`
-2. `create`
-3. `get`
-4. `list`
-5. `update`
-6. `search`
-7. `delete`
-8. verify removed from get/list/search
-
-## Acceptance Criteria
-
-Core Ticket Lifecycle CRUD is complete when:
-
-- tickets are persisted as markdown files in the documented directory layout
-- `vtic init/create/get/list/update/delete` work from the CLI
-- ticket IDs are auto-generated from category prefixes
-- title changes regenerate slugs correctly
-- updates are partial and preserve untouched fields
-- all writes are atomic
-- list filtering works on core metadata
-- BM25 keyword search works with markdown as the source of truth
-- test suite covers model, storage, CLI, search, and integration layers
+### Directory Structure
+
+```
+tickets/
+├── {owner}/                    # e.g., "ejacklab"
+│   └── {repo}/                 # e.g., "open-dsearch"
+│       └── {category}/         # e.g., "security"
+│           └── {id}-{slug}.md  # e.g., "S1-cors-wildcard.md"
+└── .trash/                     # soft-deleted tickets
+    └── {id}-{slug}.md
+```
+
+### TicketStore Class
+
+```python
+class TicketStore:
+    """Markdown file-based ticket storage."""
+    
+    def __init__(self, base_dir: Path):
+        """Initialize store with base directory path.
+        Creates base_dir/.trash/ if not exists."""
+        self.base_dir = base_dir
+        self.trash_dir = base_dir / ".trash"
+    
+    def save(self, ticket: Ticket) -> None:
+        """Write ticket as markdown file. Atomic: write to temp, then rename.
+        Raises TicketAlreadyExistsError if file exists.
+        Raises TicketWriteError on IO failure.
+        Creates parent directories as needed."""
+        ...
+    
+    def get(self, ticket_id: str) -> Ticket:
+        """Read ticket by ID. Case-insensitive lookup.
+        Scans directory tree to find file matching ID prefix.
+        Raises TicketNotFoundError if not found.
+        Raises TicketReadError on parse/IO failure."""
+        ...
+    
+    def update(self, ticket: Ticket) -> None:
+        """Overwrite existing ticket file. Atomic write.
+        Raises TicketNotFoundError if original file missing.
+        Raises TicketWriteError on IO failure."""
+        ...
+    
+    def delete(self, ticket_id: str) -> None:
+        """Permanently delete ticket file and parent dirs if empty.
+        Raises TicketNotFoundError if not found."""
+        ...
+    
+    def move_to_trash(self, ticket_id: str) -> None:
+        """Move ticket to .trash/ directory.
+        Raises TicketNotFoundError if not found."""
+        ...
+    
+    def exists(self, ticket_id: str) -> bool:
+        """Check if ticket exists. Case-insensitive."""
+        ...
+    
+    def list(self, filters: Optional[SearchFilters] = None) -> list[Ticket]:
+        """List all tickets, optionally filtered. Walk directory tree."""
+        ...
+    
+    def list_ids(self) -> set[str]:
+        """Return all ticket IDs. Used by ID generator."""
+        ...
+    
+    # --- Internal ---
+    
+    def _ticket_path(self, ticket: Ticket) -> Path:
+        """Build full path: base_dir/repo/category/id-slug.md"""
+        ...
+    
+    def _find_ticket_file(self, ticket_id: str) -> Path:
+        """Walk directory tree to find file matching ticket_id.
+        Returns Path or raises TicketNotFoundError."""
+        ...
+    
+    def _write_markdown(self, path: Path, ticket: Ticket) -> None:
+        """Serialize ticket to markdown with YAML frontmatter.
+        Write to temp file in same directory, then os.rename()."""
+        ...
+    
+    def _parse_markdown(self, path: Path) -> Ticket:
+        """Parse markdown file into Ticket model.
+        Split on '---' delimiters, parse YAML frontmatter,
+        extract <!-- DESCRIPTION --> and <!-- FIX --> sections."""
+        ...
+```
+
+### YAML Frontmatter Parsing
+
+Use `pyyaml` directly (avoid `python-frontmatter` dependency):
+
+```python
+import yaml
+
+def _parse_markdown(path: Path) -> Ticket:
+    content = path.read_text(encoding="utf-8")
+    
+    # Split frontmatter
+    if not content.startswith("---\n"):
+        raise TicketReadError(path.name, "Missing YAML frontmatter")
+    
+    parts = content.split("---\n", 2)
+    if len(parts) < 3:
+        raise TicketReadError(path.name, "Invalid frontmatter format")
+    
+    frontmatter = yaml.safe_load(parts[1])
+    body = parts[2].strip()
+    
+    # Extract sections from body
+    description = _extract_section(body, "DESCRIPTION")
+    fix = _extract_section(body, "FIX")
+    
+    # Merge sections into frontmatter
+    if description:
+        frontmatter["description"] = description
+    if fix:
+        frontmatter["fix"] = fix
+    
+    return Ticket(**frontmatter)
+
+def _extract_section(body: str, section_name: str) -> Optional[str]:
+    """Extract content between <!-- SECTION --> markers."""
+    pattern = rf"<!--\s*{section_name}\s*-->\s*\n(.*?)(?=\n<!--|$)"
+    match = re.search(pattern, body, re.DOTALL)
+    return match.group(1).strip() if match else None
+
+def _write_markdown(path: Path, ticket: Ticket) -> None:
+    """Build markdown string and write atomically."""
+    # Build frontmatter dict (exclude description/fix)
+    fm = ticket.model_dump(exclude={"description", "fix"}, mode="json")
+    
+    # Convert enums to values
+    for key in ("category", "severity", "status"):
+        if key in fm and hasattr(fm[key], "value"):
+            fm[key] = fm[key].value
+    # Convert datetime to ISO string
+    for key in ("created_at", "updated_at"):
+        if key in fm:
+            fm[key] = fm[key].isoformat() if isinstance(fm[key], datetime) else str(fm[key])
+    
+    lines = ["---", yaml.dump(fm, default_flow_style=False, allow_unicode=True).rstrip(), "---", ""]
+    
+    if ticket.description:
+        lines.extend(["<!-- DESCRIPTION -->", ticket.description, ""])
+    if ticket.fix:
+        lines.extend(["<!-- FIX -->", ticket.fix, ""])
+    
+    content = "\n".join(lines) + "\n"
+    
+    # Atomic write: temp file + rename
+    tmp_path = path.with_suffix(".tmp")
+    try:
+        tmp_path.write_text(content, encoding="utf-8")
+        tmp_path.rename(path)
+    except Exception:
+        tmp_path.unlink(missing_ok=True)
+        raise
+```
+
+---
+
+## 6. CLI Commands (`src/vtic/cli/main.py`)
+
+### App Setup
+
+```python
+import typer
+from rich.console import Console
+
+app = typer.Typer(
+    name="vtic",
+    help="Lightweight, local-first ticket system",
+    no_args_is_help=True,
+)
+console = Console()
+```
+
+### `vtic init`
+
+```python
+@app.command()
+def init(
+    dir: Path = typer.Argument(..., help="Ticket storage directory"),
+) -> None:
+    """Initialize ticket storage directory."""
+    # 1. Create dir if not exists
+    # 2. Create dir/.trash/ 
+    # 3. Create vtic.toml in CWD (or dir?) with default config
+    # 4. Print success message with path
+    # Exit: 0
+```
+
+### `vtic create`
+
+```python
+@app.command()
+def create(
+    title: str = typer.Option(..., "--title", "-t", help="Ticket title"),
+    repo: str = typer.Option(..., "--repo", "-r", help="Repository (owner/repo)"),
+    category: Category = typer.Option(Category.CODE_QUALITY, "--category", "-c"),
+    severity: Severity = typer.Option(Severity.MEDIUM, "--severity", "-s"),
+    description: Optional[str] = typer.Option(None, "--description", "-d"),
+    file: Optional[str] = typer.Option(None, "--file", "-f", help="File reference (path:line)"),
+    tags: Optional[str] = typer.Option(None, "--tags", help="Comma-separated tags"),
+) -> None:
+    """Create a new ticket."""
+    # 1. Parse tags string → list[str]
+    # 2. Build TicketCreate
+    # 3. Call TicketService.create()
+    # 4. Print created ticket summary (table format)
+    # Exit: 0 success, 2 validation error
+```
+
+### `vtic get`
+
+```python
+@app.command()
+def get(
+    ticket_id: str = typer.Argument(..., help="Ticket ID (e.g., C1)"),
+    format: str = typer.Option("table", "--format", "-F", help="Output format"),
+    raw: bool = typer.Option(False, "--raw", help="Output raw markdown"),
+) -> None:
+    """Get a ticket by ID."""
+    # 1. Call TicketService.get(ticket_id)
+    # 2. If raw: print raw markdown file
+    # 3. If format=="json": print TicketResponse.model_dump_json()
+    # 4. If format=="table": print Rich table
+    # 5. If format=="markdown": print formatted markdown
+    # Exit: 0 success, 1 not found, 2 invalid format
+```
+
+### `vtic list`
+
+```python
+@app.command()
+def list_tickets(
+    repo: Optional[str] = typer.Option(None, "--repo", "-r"),
+    severity: Optional[Severity] = typer.Option(None, "--severity", "-s"),
+    status: Optional[Status] = typer.Option(None, "--status"),
+    category: Optional[Category] = typer.Option(None, "--category", "-c"),
+    limit: int = typer.Option(50, "--limit", "-n"),
+    offset: int = typer.Option(0, "--offset"),
+    format: str = typer.Option("table", "--format", "-F"),
+) -> None:
+    """List tickets with optional filters."""
+    # 1. Build SearchFilters from args
+    # 2. Call TicketService.list(filters, limit, offset)
+    # 3. Output as table/json
+    # Exit: 0
+```
+
+### `vtic update`
+
+```python
+@app.command()
+def update(
+    ticket_id: str = typer.Argument(..., help="Ticket ID"),
+    title: Optional[str] = typer.Option(None, "--title", "-t"),
+    status: Optional[Status] = typer.Option(None, "--status"),
+    severity: Optional[Severity] = typer.Option(None, "--severity", "-s"),
+    category: Optional[Category] = typer.Option(None, "--category", "-c"),
+    description: Optional[str] = typer.Option(None, "--description", "-d"),
+    fix: Optional[str] = typer.Option(None, "--fix"),
+    tags: Optional[str] = typer.Option(None, "--tags"),
+) -> None:
+    """Update ticket fields."""
+    # 1. Build TicketUpdate from non-None args
+    # 2. If no fields provided, print "No changes specified" and exit 2
+    # 3. Call TicketService.update(ticket_id, update)
+    # 4. Print updated ticket summary
+    # Exit: 0 success, 1 not found, 2 validation error
+```
+
+### `vtic delete`
+
+```python
+@app.command()
+def delete(
+    ticket_id: str = typer.Argument(..., help="Ticket ID"),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation"),
+    force: bool = typer.Option(False, "--force", help="Permanent delete (no trash)"),
+) -> None:
+    """Delete a ticket."""
+    # 1. If not --yes: prompt "Delete ticket {id}? [y/N]"
+    # 2. If cancelled: print "Cancelled" and exit 2
+    # 3. Call TicketService.delete(ticket_id, force=force)
+    # 4. Print "Deleted {id} (moved to trash)" or "Permanently deleted {id}"
+    # Exit: 0 success, 1 not found, 2 cancelled
+```
+
+### `vtic search`
+
+```python
+@app.command()
+def search(
+    query: str = typer.Argument(..., help="Search query"),
+    repo: Optional[str] = typer.Option(None, "--repo", "-r"),
+    severity: Optional[Severity] = typer.Option(None, "--severity", "-s"),
+    status: Optional[Status] = typer.Option(None, "--status"),
+    category: Optional[Category] = typer.Option(None, "--category", "-c"),
+    limit: int = typer.Option(10, "--limit", "-n"),
+    offset: int = typer.Option(0, "--offset"),
+) -> None:
+    """Search tickets by keyword (BM25)."""
+    # 1. Build SearchFilters from args
+    # 2. Call SearchEngine.search(query, filters, limit, offset)
+    # 3. Print results as Rich table with score column
+    # 4. Print "Found N results" summary
+    # Exit: 0
+```
+
+### Output Formatting (Rich)
+
+```python
+def format_ticket_table(ticket: Ticket) -> Table:
+    """Format ticket as Rich table for terminal display."""
+    table = Table(title=f"Ticket {ticket.id}")
+    table.add_column("Field", style="cyan")
+    table.add_column("Value")
+    table.add_row("ID", ticket.id)
+    table.add_row("Title", ticket.title)
+    table.add_row("Repo", ticket.repo)
+    table.add_row("Category", ticket.category.value)
+    table.add_row("Severity", severity_colored(ticket.severity))
+    table.add_row("Status", status_colored(ticket.status))
+    table.add_row("Owner", ticket.owner or "-")
+    table.add_row("File", ticket.file or "-")
+    table.add_row("Tags", ", ".join(ticket.tags) or "-")
+    table.add_row("Created", ticket.created_at.isoformat())
+    table.add_row("Updated", ticket.updated_at.isoformat())
+    if ticket.description:
+        table.add_row("Description", ticket.description[:200] + "..." if len(ticket.description) > 200 else ticket.description)
+    return table
+
+def format_list_table(tickets: list[Ticket]) -> Table:
+    """Format ticket list as compact table."""
+    table = Table()
+    table.add_column("ID", style="bold")
+    table.add_column("Title")
+    table.add_column("Repo")
+    table.add_column("Severity")
+    table.add_column("Status")
+    table.add_column("Category")
+    for t in tickets:
+        table.add_row(t.id, t.title, t.repo, t.severity.value, t.status.value, t.category.value)
+    return table
+```
+
+---
+
+## 7. BM25 Search (`src/vtic/search.py`)
+
+### Pure-Python BM25 Implementation
+
+```python
+import math
+import re
+from collections import Counter
+from dataclasses import dataclass, field
+
+@dataclass
+class BM25Search:
+    """In-process BM25 keyword search. No external dependencies."""
+    
+    k1: float = 1.5      # Term frequency saturation
+    b: float = 0.75       # Length normalization
+    _documents: dict[str, "IndexedDoc"] = field(default_factory=dict)
+    _avg_dl: float = 0.0
+    _N: int = 0
+    _df: Counter = field(default_factory=Counter)  # document frequency per term
+    
+    @dataclass
+    class IndexedDoc:
+        ticket_id: str
+        tokens: list[str]
+        raw_text: str
+        ticket: Ticket  # reference for filtering
+    
+    def _tokenize(self, text: str) -> list[str]:
+        """Lowercase, split on non-alphanumeric, filter empty."""
+        return [t for t in re.split(r'[^a-z0-9]+', text.lower()) if t]
+    
+    def index_ticket(self, ticket: Ticket) -> None:
+        """Add/update ticket in search index."""
+        text = ticket.search_text
+        tokens = self._tokenize(text)
+        doc = self.IndexedDoc(ticket_id=ticket.id, tokens=tokens, raw_text=text, ticket=ticket)
+        
+        # Remove old if re-indexing
+        if ticket.id in self._documents:
+            self._remove_from_stats(ticket.id)
+        
+        self._documents[ticket.id] = doc
+        self._update_stats()
+    
+    def remove_ticket(self, ticket_id: str) -> None:
+        """Remove ticket from index."""
+        if ticket_id in self._documents:
+            self._remove_from_stats(ticket_id)
+            del self._documents[ticket_id]
+            self._update_stats()
+    
+    def search(
+        self,
+        query: str,
+        filters: Optional[SearchFilters] = None,
+        limit: int = 10,
+        offset: int = 0,
+    ) -> SearchResponse:
+        """Search tickets using BM25 scoring."""
+        query_tokens = self._tokenize(query)
+        if not query_tokens:
+            return SearchResponse(results=[], total=0, query=query, limit=limit, offset=offset, has_more=False)
+        
+        scores: list[tuple[str, float]] = []
+        
+        for doc_id, doc in self._documents.items():
+            # Apply filters first
+            if filters and not self._matches_filters(doc.ticket, filters):
+                continue
+            
+            score = self._bm25_score(query_tokens, doc)
+            if score > 0:
+                scores.append((doc_id, score))
+        
+        # Sort by score descending
+        scores.sort(key=lambda x: x[1], reverse=True)
+        
+        # Paginate
+        total = len(scores)
+        page = scores[offset:offset + limit]
+        
+        results = []
+        for doc_id, score in page:
+            doc = self._documents[doc_id]
+            highlights = self._highlight(query_tokens, doc.raw_text)
+            results.append(SearchResult(
+                id=doc.ticket.id,
+                title=doc.ticket.title,
+                repo=doc.ticket.repo,
+                category=doc.ticket.category.value,
+                severity=doc.ticket.severity.value,
+                status=doc.ticket.status.value,
+                score=round(score, 4),
+                highlights=highlights,
+            ))
+        
+        return SearchResponse(
+            results=results,
+            total=total,
+            query=query,
+            limit=limit,
+            offset=offset,
+            has_more=(offset + len(results)) < total,
+        )
+    
+    def _bm25_score(self, query_tokens: list[str], doc: "IndexedDoc") -> float:
+        """Calculate BM25 score for a document."""
+        score = 0.0
+        tf = Counter(doc.tokens)
+        dl = len(doc.tokens)
+        
+        for token in query_tokens:
+            if token not in tf:
+                continue
+            
+            freq = tf[token]
+            n = self._N or 1
+            df = self._df.get(token, 0)
+            idf = math.log((n - df + 0.5) / (df + 0.5) + 1.0)
+            tf_norm = (freq * (self.k1 + 1)) / (freq + self.k1 * (1 - self.b + self.b * dl / (self._avg_dl or 1)))
+            score += idf * tf_norm
+        
+        return score
+    
+    def _matches_filters(self, ticket: Ticket, filters: SearchFilters) -> bool:
+        """Check if ticket matches all filter criteria."""
+        if filters.severity and ticket.severity not in filters.severity:
+            return False
+        if filters.status and ticket.status not in filters.status:
+            return False
+        if filters.category and ticket.category not in filters.category:
+            return False
+        if filters.repo:
+            if not any(self._glob_match(ticket.repo, pattern) for pattern in filters.repo):
+                return False
+        if filters.tags:
+            if not all(t in ticket.tags for t in filters.tags):
+                return False
+        return True
+    
+    def _glob_match(self, value: str, pattern: str) -> bool:
+        """Simple glob: '*' matches any characters within a segment."""
+        # Convert glob to regex: e.g., "ejacklab/*" → "^ejacklab/.*$"
+        regex = "^" + re.escape(pattern).replace(r"\*", ".*") + "$"
+        return bool(re.match(regex, value, re.IGNORECASE))
+    
+    def _highlight(self, query_tokens: list[str], text: str, context: int = 40) -> list[str]:
+        """Extract text snippets around matching terms."""
+        # Find first occurrence of any query token in original text
+        lower = text.lower()
+        for token in query_tokens:
+            idx = lower.find(token)
+            if idx >= 0:
+                start = max(0, idx - context)
+                end = min(len(text), idx + len(token) + context)
+                snippet = text[start:end]
+                if start > 0:
+                    snippet = "..." + snippet
+                if end < len(text):
+                    snippet = snippet + "..."
+                return [snippet]
+        return []
+    
+    def rebuild(self, tickets: list[Ticket]) -> None:
+        """Rebuild index from list of tickets."""
+        self._documents.clear()
+        self._df.clear()
+        self._N = 0
+        self._avg_dl = 0.0
+        for ticket in tickets:
+            self.index_ticket(ticket)
+```
+
+---
+
+## 8. ID Generation (`src/vtic/id_gen.py`)
+
+```python
+from vtic.constants import CATEGORY_PREFIXES, Category
+from vtic.errors import ValidationError
+
+def generate_ticket_id(category: Category, existing_ids: set[str]) -> str:
+    """
+    Generate unique ticket ID based on category prefix.
+    
+    Algorithm:
+    1. Get prefix from CATEGORY_PREFIXES for category (default "O" for unknown)
+    2. Find all existing IDs with this prefix
+    3. Extract numbers from those IDs
+    4. Find the lowest gap (starting from 1)
+    5. Return "{PREFIX}{NUMBER}"
+    
+    Examples:
+        category=Category.SECURITY, existing_ids={"S1", "S2"} → "S3"
+        category=Category.SECURITY, existing_ids={"S1", "S3"} → "S2" (gap fill)
+        category=Category.OTHER, existing_ids=set() → "O1"
+    """
+    prefix = CATEGORY_PREFIXES.get(category, "O")
+    
+    # Find existing numbers for this prefix
+    existing_numbers = set()
+    for eid in existing_ids:
+        if eid.upper().startswith(prefix):
+            num_str = eid.upper()[len(prefix):]
+            if num_str.isdigit():
+                existing_numbers.add(int(num_str))
+    
+    # Find lowest available number
+    n = 1
+    while n in existing_numbers:
+        n += 1
+    
+    return f"{prefix}{n}"
+```
+
+---
+
+## 9. Error Handling (`src/vtic/errors.py`)
+
+```python
+from pydantic import BaseModel
+
+class ErrorDetail(BaseModel):
+    field: Optional[str] = None
+    message: str
+    code: str
+
+class VticError(Exception):
+    """Base exception for all vtic errors."""
+    
+    def __init__(
+        self,
+        error_code: str,
+        message: str,
+        status_code: int = 500,
+        details: list[ErrorDetail] | None = None,
+    ):
+        self.error_code = error_code
+        self.message = message
+        self.status_code = status_code
+        self.details = details or []
+        super().__init__(message)
+
+class TicketNotFoundError(VticError):
+    def __init__(self, ticket_id: str):
+        super().__init__(
+            error_code="TICKET_NOT_FOUND",
+            message=f"Ticket {ticket_id} not found",
+            status_code=404,
+        )
+
+class TicketAlreadyExistsError(VticError):
+    def __init__(self, ticket_id: str):
+        super().__init__(
+            error_code="TICKET_ALREADY_EXISTS",
+            message=f"Ticket {ticket_id} already exists",
+            status_code=409,
+        )
+
+class TicketWriteError(VticError):
+    def __init__(self, ticket_id: str, details: str):
+        super().__init__(
+            error_code="TICKET_WRITE_ERROR",
+            message=f"Failed to write ticket {ticket_id}: {details}",
+            status_code=500,
+        )
+
+class TicketReadError(VticError):
+    def __init__(self, ticket_id: str, details: str):
+        super().__init__(
+            error_code="TICKET_READ_ERROR",
+            message=f"Failed to read ticket {ticket_id}: {details}",
+            status_code=500,
+        )
+
+class ValidationError(VticError):
+    def __init__(self, message: str, details: list[ErrorDetail] | None = None):
+        super().__init__(
+            error_code="VALIDATION_ERROR",
+            message=message,
+            status_code=400,
+            details=details,
+        )
+
+class ConfigError(VticError):
+    def __init__(self, message: str):
+        super().__init__(
+            error_code="CONFIG_ERROR",
+            message=message,
+            status_code=500,
+        )
+```
+
+### CLI Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 1 | Not found (ticket, config) |
+| 2 | Validation error / user cancelled |
+| 3 | Config error / not initialized |
+| 130 | Ctrl+C (SIGINT) — let Typer handle |
+
+---
+
+## 10. Ticket Service (`src/vtic/ticket.py`)
+
+```python
+class TicketService:
+    """High-level ticket CRUD orchestration."""
+    
+    def __init__(self, store: TicketStore, search: BM25Search):
+        self.store = store
+        self.search = search
+    
+    def create(self, data: TicketCreate) -> Ticket:
+        """Create a new ticket.
+        1. Validate required fields (Pydantic handles this)
+        2. Generate ID: generate_ticket_id(data.category, store.list_ids())
+        3. Generate slug: slugify(data.title)
+        4. Set timestamps: now = utcnow()
+        5. Build Ticket model
+        6. store.save(ticket) — atomic write
+        7. search.index_ticket(ticket)
+        8. Return ticket
+        Raises: TicketAlreadyExistsError (shouldn't happen with auto-ID), ValidationError
+        """
+        ...
+    
+    def get(self, ticket_id: str) -> Ticket:
+        """Get ticket by ID. Case-insensitive.
+        Delegates to store.get().
+        Raises: TicketNotFoundError"""
+        ...
+    
+    def update(self, ticket_id: str, update: TicketUpdate) -> Ticket:
+        """Update ticket fields.
+        1. Fetch existing: store.get(ticket_id)
+        2. Merge update fields (only non-None)
+        3. Refresh updated_at = utcnow()
+        4. Recalculate slug if title changed
+        5. store.update(ticket)
+        6. search.index_ticket(ticket) — re-index
+        7. Return updated ticket
+        Raises: TicketNotFoundError, ValidationError"""
+        ...
+    
+    def delete(self, ticket_id: str, force: bool = False) -> None:
+        """Delete ticket.
+        1. Verify exists: store.exists(ticket_id)
+        2. If force: store.delete(ticket_id)
+        3. Else: store.move_to_trash(ticket_id)
+        4. search.remove_ticket(ticket_id)
+        Raises: TicketNotFoundError"""
+        ...
+    
+    def list(
+        self,
+        filters: SearchFilters | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[Ticket]:
+        """List tickets with filters.
+        Delegates to store.list(filters), then paginate."""
+        ...
+    
+    def search(
+        self,
+        query: str,
+        filters: SearchFilters | None = None,
+        limit: int = 10,
+        offset: int = 0,
+    ) -> SearchResponse:
+        """Search tickets using BM25.
+        Delegates to search.search()."""
+        ...
+```
+
+---
+
+## 11. Config (`src/vtic/config.py`)
+
+```python
+from pathlib import Path
+import tomllib
+
+class TicketsConfig(BaseModel):
+    dir: Path = Field(default=Path("./tickets"))
+    
+    @field_validator("dir")
+    @classmethod
+    def validate_dir(cls, v: Path) -> Path:
+        return v.expanduser().resolve()
+
+class ServerConfig(BaseModel):
+    host: str = "127.0.0.1"
+    port: int = Field(default=8900, ge=1, le=65535)
+
+class SearchConfig(BaseModel):
+    bm25_enabled: bool = True
+
+class VticConfig(BaseModel):
+    tickets: TicketsConfig = Field(default_factory=TicketsConfig)
+    server: ServerConfig = Field(default_factory=ServerConfig)
+    search: SearchConfig = Field(default_factory=SearchConfig)
+    
+    @classmethod
+    def from_toml(cls, path: Path) -> "VticConfig": ...
+    
+    @classmethod
+    def from_env(cls) -> "VticConfig": ...
+    
+    @classmethod
+    def load(cls) -> "VticConfig":
+        """Load config: check CWD vtic.toml → ~/.config/vtic/config.toml → defaults.
+        Override with VTIC_* env vars."""
+        ...
+
+_config: VticConfig | None = None
+
+def get_config() -> VticConfig:
+    """Singleton config access."""
+    global _config
+    if _config is None:
+        _config = VticConfig.load()
+    return _config
+
+def init_config(tickets_dir: Path) -> None:
+    """Write default vtic.toml to current directory."""
+    config = VticConfig(tickets=TicketsConfig(dir=tickets_dir))
+    # Write TOML
+    ...
+```
+
+---
+
+## 12. Test Plan
+
+### conftest.py Fixtures
+
+```python
+import pytest
+from pathlib import Path
+from typer.testing import CliRunner
+
+@pytest.fixture
+def tmp_store(tmp_path):
+    """TicketStore pointing to a temp directory."""
+    from vtic.store import TicketStore
+    store = TicketStore(tmp_path / "tickets")
+    store.base_dir.mkdir(parents=True, exist_ok=True)
+    store.trash_dir.mkdir(exist_ok=True)
+    return store
+
+@pytest.fixture
+def sample_ticket():
+    """A valid Ticket instance for testing."""
+    from vtic.models import Ticket
+    from datetime import datetime, timezone
+    return Ticket(
+        id="S1",
+        title="CORS Wildcard in Production",
+        repo="ejacklab/open-dsearch",
+        category=Category.SECURITY,
+        severity=Severity.CRITICAL,
+        status=Status.OPEN,
+        created_at=datetime(2026, 3, 16, 10, 0, 0, tzinfo=timezone.utc),
+        updated_at=datetime(2026, 3, 16, 10, 0, 0, tzinfo=timezone.utc),
+        slug="cors-wildcard-in-production",
+        description="All FastAPI services use allow_origins=['*']",
+        tags=["cors", "security"],
+    )
+
+@pytest.fixture
+def populated_store(tmp_store, sample_ticket):
+    """Store with one ticket pre-saved."""
+    tmp_store.save(sample_ticket)
+    return tmp_store
+
+@pytest.fixture
+def cli_runner():
+    """Typer CLI test runner."""
+    return CliRunner()
+```
+
+### test_models.py (25 tests)
+
+| Test | What it verifies |
+|------|-----------------|
+| `test_severity_values` | All 4 severity values exist |
+| `test_status_values` | All 6 status values exist |
+| `test_category_values` | All 15 category values exist |
+| `test_ticket_valid_minimal` | Ticket with only required fields |
+| `test_ticket_valid_all_fields` | Ticket with all fields populated |
+| `test_ticket_id_format_valid` | Accepts "C1", "S99" |
+| `test_ticket_id_format_invalid` | Rejects "1", "abc", "C", "c1" |
+| `test_ticket_id_uppercased` | "c1" → "C1" |
+| `test_ticket_repo_format_valid` | Accepts "owner/repo" |
+| `test_ticket_repo_format_invalid` | Rejects "repo", "a/b/c" |
+| `test_ticket_repo_lowercased` | "Owner/Repo" → "owner/repo" |
+| `test_ticket_title_empty_rejected` | Empty/whitespace title raises |
+| `test_ticket_tags_normalized` | Lowercase, dedup, max 50 |
+| `test_ticket_tags_too_many` | 51 tags raises |
+| `test_ticket_timestamps_valid` | updated_at >= created_at |
+| `test_ticket_timestamps_invalid` | updated_at < created_at raises |
+| `test_ticket_filename` | "C1" + "bug" → "C1-bug.md" |
+| `test_ticket_filepath` | "{repo}/{category}/{filename}" |
+| `test_ticket_is_terminal` | fixed/wont_fix/closed = True |
+| `test_ticket_create_defaults` | category=code_quality, severity=medium, status=open |
+| `test_ticket_update_all_optional` | All fields Optional |
+| `test_ticket_update_extra_forbidden` | extra="forbid" rejects unknown fields |
+| `test_ticket_response_from_ticket` | Conversion preserves all fields |
+| `test_ticket_search_text` | Combines title+description+fix+tags |
+
+### test_id_gen.py (8 tests)
+
+| Test | What it verifies |
+|------|-----------------|
+| `test_first_id_in_category` | Empty set → prefix + "1" |
+| `test_sequential_ids` | S1,S2 → S3 |
+| `test_gap_filling` | S1,S3 → S2 |
+| `test_unknown_category` | No prefix → "O1" |
+| `test_mixed_categories` | S1,C1,C2 → C3 |
+| `test_empty_existing_ids` | Any category → X1 |
+| `test_large_gap` | S1,S100 → S2 |
+| `test_all_prefixes` | Each category gets correct prefix |
+
+### test_store.py (18 tests)
+
+| Test | What it verifies |
+|------|-----------------|
+| `test_save_and_get_roundtrip` | Write ticket → read back → fields match |
+| `test_save_creates_directories` | Missing dirs are created |
+| `test_save_atomic_write` | No partial files on crash (check no .tmp after save) |
+| `test_save_duplicate_raises` | Save same ID twice → TicketAlreadyExistsError |
+| `test_get_not_found` | Non-existent ID → TicketNotFoundError |
+| `test_get_case_insensitive` | "s1" finds "S1" |
+| `test_update_overwrites` | Save → update → get returns new values |
+| `test_delete_removes_file` | File gone after delete |
+| `test_delete_not_found` | Non-existent ID → TicketNotFoundError |
+| `test_move_to_trash` | File in .trash/ after soft delete |
+| `test_move_to_trash_creates_trash_dir` | .trash/ auto-created |
+| `test_exists_true` | Returns True for existing ticket |
+| `test_exists_false` | Returns False for missing ticket |
+| `test_list_returns_all` | Multiple tickets all listed |
+| `test_list_with_filters` | Only matching tickets returned |
+| `test_list_ids` | Returns set of ID strings |
+| `test_parse_frontmatter` | YAML frontmatter correctly parsed |
+| `test_parse_description_section` | <!-- DESCRIPTION --> content extracted |
+
+### test_search.py (12 tests)
+
+| Test | What it verifies |
+|------|-----------------|
+| `test_exact_match_highest_score` | Exact term scores higher than partial |
+| `test_no_results_empty_query` | Empty string returns empty |
+| `test_filter_by_severity` | Only matching severity in results |
+| `test_filter_by_status` | Only matching status in results |
+| `test_filter_by_repo_glob` | "ejacklab/*" matches repos |
+| `test_pagination_limit_offset` | Correct page of results |
+| `test_highlight_snippet` | Query term appears in highlight |
+| `test_reindex_rebuilds` | Clear + rebuild produces same results |
+| `test_remove_ticket_excluded` | Deleted ticket not in results |
+| `test_special_characters_ignored` | Query with symbols still works |
+| `test_multiple_terms_better_than_single` | "CORS wildcard" scores higher than "CORS" alone |
+| `test_score_ordering` | Results sorted by score descending |
+
+### test_cli.py (20 tests)
+
+| Test | What it verifies |
+|------|-----------------|
+| `test_init_creates_directory` | `vtic init ./tmp` creates dir |
+| `test_init_creates_trash` | .trash/ subdirectory created |
+| `test_init_creates_config` | vtic.toml written |
+| `test_create_minimal` | `vtic create -t "Bug" -r "owner/repo"` succeeds |
+| `test_create_with_all_options` | All flags accepted |
+| `test_create_invalid_repo` | Bad repo format → exit code 2 |
+| `test_get_existing` | Shows ticket in table format |
+| `test_get_json_format` | Valid JSON output with --format json |
+| `test_get_not_found` | Exit code 1 |
+| `test_get_raw` | --raw outputs markdown |
+| `test_list_empty` | No tickets → "No tickets found" |
+| `test_list_with_filter` | --severity critical filters correctly |
+| `test_update_status` | --status fixed updates ticket |
+| `test_update_multiple_fields` | Combined flags work |
+| `test_update_not_found` | Exit code 1 |
+| `test_delete_with_yes` | --yes skips prompt, exit 0 |
+| `test_delete_force` | --force permanent delete |
+| `test_delete_not_found` | Exit code 1 |
+| `test_search_query` | Returns matching tickets |
+| `test_search_with_filter` | Combined query + filter |
+
+### test_config.py (6 tests)
+
+| Test | What it verifies |
+|------|-----------------|
+| `test_default_config` | No file → defaults |
+| `test_load_toml` | Parse valid vtic.toml |
+| `test_env_override` | VTIC_TICKETS_DIR overrides |
+| `test_config_cwd_precedence` | CWD config > global config |
+| `test_invalid_toml` | Bad TOML → ConfigError |
+| `test_init_config_writes_file` | init_config creates vtic.toml |
+
+### test_errors.py (5 tests)
+
+| Test | What it verifies |
+|------|-----------------|
+| `test_error_base_properties` | error_code, message, status_code |
+| `test_ticket_not_found_404` | Correct attributes |
+| `test_validation_error_400` | Correct attributes + details |
+| `test_error_inheritance` | All errors are VticError |
+| `test_error_str` | str(error) == message |
+
+**Total: ~94 tests**
+
+---
+
+## 13. Constants (`src/vtic/constants.py`)
+
+```python
+from vtic.models import Category
+
+CATEGORY_PREFIXES: dict[Category, str] = {
+    Category.CODE_QUALITY: "C",
+    Category.SECURITY: "S",
+    Category.AUTH: "A",
+    Category.INFRASTRUCTURE: "I",
+    Category.DOCUMENTATION: "D",
+    Category.TESTING: "T",
+    Category.PERFORMANCE: "P",
+    Category.FRONTEND: "F",
+    Category.CONFIGURATION: "N",
+    Category.API: "X",
+    Category.DATA: "M",
+    Category.UI: "U",
+    Category.DEPENDENCIES: "Y",
+    Category.BUILD: "B",
+    Category.OTHER: "O",
+}
+
+TERMINAL_STATUSES: set[str] = {"fixed", "wont_fix", "closed"}
+
+STATUS_METADATA: dict[str, dict] = {
+    "open": {"display_name": "Open", "color": "blue"},
+    "in_progress": {"display_name": "In Progress", "color": "yellow"},
+    "blocked": {"display_name": "Blocked", "color": "red"},
+    "fixed": {"display_name": "Fixed", "color": "green"},
+    "wont_fix": {"display_name": "Won't Fix", "color": "dim"},
+    "closed": {"display_name": "Closed", "color": "cyan"},
+}
+```
+
+---
+
+## 14. Next Steps for 2am Scaffold Job
+
+The scaffold job should:
+
+1. **Create all files** listed in Section 2 following the exact signatures in Sections 4-12
+2. **Copy model code** from DATA_MODELS.md almost verbatim — the spec is the contract
+3. **Implement store.py first** — it's the critical path; everything else depends on file I/O
+4. **Wire up CLI last** — after all services work in isolation
+5. **Run tests incrementally** — don't wait until all files exist:
+   - After Phase 1: `pytest tests/test_models.py tests/test_constants.py tests/test_errors.py`
+   - After Phase 2: `pytest tests/test_id_gen.py tests/test_store.py tests/test_config.py`
+   - After Phase 3: `pytest tests/test_ticket.py tests/test_search.py`
+   - After Phase 4: `pytest tests/test_cli.py`
+   - Full: `pytest tests/ -v --cov=vtic`
+6. **Target: green test suite** — all ~94 tests passing before commit
+7. **Commit message**: `feat: scaffold core ticket lifecycle CRUD (v0.1 MVP)`
+
+### Estimated File Sizes
+
+| File | Lines (est.) |
+|------|-------------|
+| models.py | ~300 |
+| config.py | ~120 |
+| errors.py | ~80 |
+| constants.py | ~40 |
+| utils.py | ~30 |
+| id_gen.py | ~30 |
+| store.py | ~250 |
+| ticket.py | ~120 |
+| search.py | ~200 |
+| cli/main.py | ~350 |
+| **Source total** | **~1520** |
+| tests/*.py | ~1200 |
+| **Grand total** | **~2720** |

--- a/REVIEW_ROUND1.md
+++ b/REVIEW_ROUND1.md
@@ -1,152 +1,269 @@
-# Code Review — Round 1
+# Code Review: vtic — Round 1
 
-**Reviewer:** Codex (static analysis, read-only sandbox)  
-**Date:** 2026-04-06  
+**Date:** 2026-04-08  
+**Reviewer:** Hermes Agent (manual review — Codex auth token expired)  
 **Branch:** `feat/ticket-lifecycle-core`  
-**Test Baseline:** 139 passed in 0.84s
+**Test status:** ✅ 159/159 passed (0.99s)  
+**Files reviewed:** 11 source, 8 test
 
 ---
 
-## Critical Findings
+## Summary
 
-### 1. `storage.py:164` & `storage.py:177` — Lost-update race in `TicketStore.update()`
+The codebase is well-structured, with clean separation of concerns (models, storage, search, API, CLI) and solid defensive practices (path traversal protection, atomic file writes, concurrent ID generation). Pydantic v2 validation is thorough, and test coverage is good at ~159 tests. The issues below are mostly minor to moderate — no critical bugs were found, but several areas deserve attention before merge.
 
-**Severity:** CRITICAL  
-**Files:** `src/vtic/storage.py`
-
-`TicketStore.update()` acquires a lock, reads the current ticket state, releases the lock, then re-acquires a new lock before writing. This creates a race window where concurrent `update()`, `delete()`, or `restore_from_trash()` calls can:
-
-- Overwrite newer ticket state with stale data (lost update)
-- "Resurrect" a deleted ticket if `update()` races with `delete()`
-- Corrupt ticket state when two updates race
-
-**Recommendation:** Keep the entire read-modify-write sequence under a single exclusive lock. The write-and-rename at the end must use the same lock held during the read.
-
-Additionally, `move_to_trash()`, `restore_from_trash()`, and forced `delete()` operations are not under the same lock discipline as `update()`, creating similar windows for concurrent operations involving those methods.
+**Totals:** 0 critical · 3 warning · 11 info
 
 ---
 
-## Warnings
+## WARNING Findings
 
-### 2. `storage.py:170` — Cannot clear nullable fields via update
+### W1. `Category.AUTH` value is `"***"` — corrupt/masked value in spec and implementation
 
-**Severity:** WARNING  
-**File:** `src/vtic/storage.py`, line 170
+**File:** `src/vtic/models.py:39`, `DATA_MODELS.md`  
+**Severity:** ⚠️ WARNING
 
 ```python
-update_data = updates.model_dump(exclude_none=True)
+AUTH="***"
 ```
 
-`exclude_none=True` silently drops any `None` values, making it impossible to clear `description`, `fix`, `file`, or `tags` through the API or CLI. Sending `{"fix": null}` is treated as "no change", contradicting the `Optional[...]` update model in `DATA_MODELS.md`.
+The `AUTH` enum member has its value set to `"***"` instead of `"auth"`. This matches the DATA_MODELS.md spec literally (which also shows `AUTH="***"`), but this is almost certainly a placeholder or redaction artifact that was never resolved. The result:
 
-**Recommendation:** Use `exclude_unset=True` so that explicit `null` clears the field while omitted fields remain unchanged.
+- `Category.AUTH.value == "***"` — not `"auth"`
+- `CATEGORY_PREFIXES[Category.AUTH]` would map to prefix `"A"` (correct), but any code using `Category.AUTH.value` for file paths, search indexing, or CLI display would produce `"***"` instead of `"auth"`
+- Ticket files for auth category would be stored under a directory literally named `***`
+- Search filters with `category=["auth"]` would NOT match tickets with `Category.AUTH` because `Category.AUTH.value` is `"***"`, not `"auth"`
 
-### 3. `models.py:351` / `storage.py:417` — No date-range validation
-
-**Severity:** WARNING  
-**Files:** `src/vtic/models.py`, `src/vtic/storage.py`
-
-`SearchFilters` does not validate contradictory date ranges (e.g., `created_after > created_before`). `DATA_MODELS.md` defines `INVALID_DATE_RANGE` for this case, but today such requests silently return empty results.
-
-**Recommendation:** Add a `model_validator` to `SearchFilters` that rejects `created_after > created_before` and `updated_after > updated_before` with an appropriate error.
-
-### 4. `api.py:40` & `api.py:53` — HTTP status code mismatch with spec
-
-**Severity:** WARNING  
-**File:** `src/vtic/api.py`
-
-Malformed JSON and validation failures both return HTTP 422, but `DATA_MODELS.md`'s error catalog specifies:
-- `VALIDATION_ERROR` → 400
-- `INVALID_REQUEST` → 400
-
-The internal behavior is consistent, but it does not match the documented contract.
-
-**Recommendation:** Change error handlers to emit 400 with the documented error codes, or update `DATA_MODELS.md` to match the implementation.
-
-### 5. `cli/main.py:335` — Under-validated `serve --port` CLI option
-
-**Severity:** WARNING  
-**File:** `src/vtic/cli/main.py`
-
-`typer.Option(None, "--port")` accepts any integer, while `config.py` correctly restricts ports to `1..65535` via Pydantic. CLI validation is weaker than schema validation.
-
-**Recommendation:** Add `min=1, max=65535` to the Typer port option.
-
-### 6. `storage.py:169` / `models.py:198` — Slug not recomputed on title change
-
-**Severity:** WARNING  
-**Files:** `src/vtic/storage.py`, `src/vtic/models.py`
-
-The spec treats `slug` as a derived field, but `update()` preserves the old slug when title changes. The filename and `filepath` can become out of sync with the current title.
-
-**Recommendation:** Recompute `slug` when `title` is changed and rename the markdown file accordingly.
-
-### 7. `storage.py:5` — `fcntl` hard dependency blocks Windows
-
-**Severity:** WARNING  
-**File:** `src/vtic/storage.py`
-
-The storage layer imports `fcntl`, which is POSIX-only. This prevents the package from working on Windows. If cross-platform support matters, replace with a cross-platform locking mechanism (e.g., `filelock`, `portalocker`).
-
-### 8. `search.py:253` & `search.py:268` — Full corpus re-parsed on every search
-
-**Severity:** WARNING  
-**Files:** `src/vtic/search.py`
-
-Every search call re-parses the full markdown corpus via `store.list()` before the cached BM25 index is even consulted. The persisted index only saves tokenization work, not the dominant filesystem scan/parse cost. This will become a bottleneck for larger ticket sets.
-
-**Recommendation:** Consider a metadata cache or incremental index that avoids re-parsing unchanged tickets on each query.
-
-### 9. `cli/main.py:189` & `cli/main.py:196` — PEP 8 line-length violations
-
-**Severity:** INFO  
-**File:** `src/vtic/cli/main.py`
-
-Multiple lines exceed the conventional 88-character limit (Black default). Not a runtime issue, but the project is not fully PEP 8 clean.
+**Impact:** Auth-category tickets are functionally broken for storage path generation and search filtering.  
+**Fix:** Change to `AUTH = "auth"` in both `models.py` and `DATA_MODELS.md`.
 
 ---
 
-## Direct Security / Correctness Checks
+### W2. `create()` method has no file locking — race condition on duplicate ticket creation
 
-### Path Traversal in Markdown I/O
-**Result:** No direct path-traversal bug found in normal write paths.  
-`utils.py:67` resolves the target path and rejects anything escaping `base_dir`. Repo parsing rejects `.` / `..` segments at `utils.py:41`.
+**File:** `src/vtic/storage.py:69-77`  
+**Severity:** ⚠️ WARNING
 
-### CLI Input Validation
-**Result:** Mostly good for enums and required fields. The `serve --port` option is under-validated (see #5 above).
+```python
+def create(self, ticket: Ticket) -> Ticket:
+    """Write a pre-validated ticket directly.
+    This is a low-level helper and does not provide atomic ID allocation.
+    Callers that need safe concurrent creation should use `create_ticket()`.
+    """
+    path = ticket_path(self.base_dir, ticket)
+    self._write_ticket(ticket, path)
+    return ticket
+```
 
-### API Malformed Request Handling
-**Result:** Handled with structured error bodies, but the HTTP status/error code contract differs from `DATA_MODELS.md` (see #4 above).
+The docstring correctly warns that this is low-level and lacks locking, but the method is public. If any caller (or future code) uses `create()` instead of `create_ticket()` for concurrent writes, they lose ID-allocation safety. The API layer in `api.py` uses `store.create_ticket()`, which is correct. However, some tests call `store.create()` directly.
 
-### Race Conditions in ID Generation
-**Result:** The public `create_ticket()` path is reasonably safe on POSIX. `storage.py:67` allocates and writes under one exclusive lock. The race issue is in updates/deletes, not in `create_ticket()` itself (see #1 above).
-
-### Empty Query Search
-**Result:** Handled gracefully. `search.py:274` returns filtered tickets, stable-sorted by ID, with score `1.0`.
-
----
-
-## Test Coverage Gaps
-
-| Gap | Location |
-|-----|----------|
-| Concurrent update/delete/restore races | `tests/test_storage.py` — only concurrent creation is tested |
-| Clearing nullable fields via update | `tests/test_storage.py:283`, `tests/test_api.py:241` — only value-setting is tested |
-| Invalid date range validation | No tests found for model, API, or CLI |
-| Error catalog contract (400 vs 422) | `tests/test_api.py:310`, `tests/test_api.py:327` — tests codify 422 behavior |
+**Impact:** Low risk if `create_ticket()` is consistently used in production code paths. The public API doesn't expose `create()` directly.  
+**Fix:** Consider making `create()` a private method (`_create()`), or at minimum rename to `_write_ticket_direct()` to reduce misuse surface.
 
 ---
 
-## Summary Table
+### W3. `update()` doesn't validate that `repo` field is not being changed
 
-| # | Severity | File | Issue |
-|---|----------|------|-------|
-| 1 | CRITICAL | `storage.py:164,177` | Lost-update race in `update()` |
-| 2 | WARNING | `storage.py:170` | Cannot clear nullable fields |
-| 3 | WARNING | `models.py:351`, `storage.py:417` | No date-range validation |
-| 4 | WARNING | `api.py:40,53` | HTTP 422 vs spec's 400 |
-| 5 | WARNING | `cli/main.py:335` | `serve --port` under-validated |
-| 6 | WARNING | `storage.py:169`, `models.py:198` | Slug not recomputed on title change |
-| 7 | WARNING | `storage.py:5` | `fcntl` blocks Windows |
-| 8 | WARNING | `search.py:253,268` | Full corpus re-parse per search |
-| 9 | INFO | `cli/main.py:189,196` | PEP 8 line-length violations |
+**File:** `src/vtic/storage.py:175-214`  
+**Severity:** ⚠️ WARNING
+
+When updating a ticket, the method merges `update_data` (from `TicketUpdate`) into the existing ticket data dict. `TicketUpdate` doesn't include a `repo` field (by design — `extra="forbid"`), so this is currently safe. However, if someone later adds `repo` to `TicketUpdate`, it would silently allow changing the repo, which would rename the file and break the ID prefix convention.
+
+The comment in `test_storage.py:656` acknowledges this: *"TicketUpdate doesn't allow changing repo directly (it's not in the model)."*
+
+**Impact:** Latent risk if the model evolves.  
+**Fix:** Add an explicit guard in `update()` that raises `ValidationError` if `repo` is in `update_data`, defensive against future changes.
+
+---
+
+## INFO Findings
+
+### I1. Redundant no-op return in `TicketUpdate` validator
+
+**File:** `src/vtic/models.py:289`  
+**Severity:** ℹ️ INFO
+
+```python
+return v if v else v
+```
+
+This is equivalent to just `return v`. The `else` branch returns the same value.
+
+**Fix:** Simplify to `return v`.
+
+---
+
+### I2. `_split_frontmatter` doesn't handle `\r\n` in the closing marker
+
+**File:** `src/vtic/storage.py:306-319`  
+**Severity:** ℹ️ INFO
+
+The method normalizes CRLF→LF at the top (`raw.replace("\r\n", "\n")`), which handles the input side. However, the closing marker search uses `\n---\n` as the delimiter. If a file has `\r\n---\r\n` after normalization this works fine, but the method hardcodes `\n---\n` which means a file ending with `---\r\n` (without a trailing LF) would fail after CRLF normalization.
+
+This is a minor edge case and is already handled by the CRLF normalization, but worth documenting the assumption.
+
+---
+
+### I3. `_matches_filters` has duplicated timezone normalization logic
+
+**File:** `src/vtic/storage.py:426-437`  
+**Severity:** ℹ️ INFO
+
+The same `replace(tzinfo=timezone.utc)` pattern is repeated 4 times for date filter comparisons:
+
+```python
+if created_after is not None and ticket.created_at < (created_after.replace(tzinfo=timezone.utc) if created_after.tzinfo is None else created_after):
+```
+
+**Fix:** Extract to a helper function like `_ensure_utc(dt: datetime) -> datetime` and reuse.
+
+---
+
+### I4. Search `total` count may be inconsistent with `offset`
+
+**File:** `src/vtic/search.py:414`  
+**Severity:** ℹ️ INFO
+
+```python
+total=len(ranked),
+```
+
+The `total` is set to `len(ranked)` which is the total number of matching results BEFORE offset is applied. This is correct for pagination (`total` should represent the full result set). However, when the BM25 fallback path is taken (non-positive scores), the `total` counts ALL filtered tickets with ANY term overlap, while the normal path only counts tickets with positive BM25 scores. This asymmetry means:
+
+- Normal path: `total` = tickets with score > 0
+- Fallback path: `total` = tickets with any term overlap
+
+Both paths are reasonable, but the inconsistency could confuse API consumers expecting deterministic totals.
+
+---
+
+### I5. `ticket_path()` is called with `ticket.repo` which could contain the `"***"` bug value
+
+**File:** `src/vtic/utils.py:67-75`  
+**Severity:** ℹ️ INFO
+
+The `ticket_path()` function calls `parse_repo(ticket.repo)` which splits on `/`. If `Category.AUTH` has value `"***"`, it would affect `ticket.category.value` in the path, NOT `ticket.repo`. However, `parse_repo` has its own `.`/`..` check but doesn't validate against `CATEGORY_PREFIXES` for the path segment. This means any Category value with path-unsafe characters (like `***`) would be used in filesystem paths.
+
+This is the downstream impact of W1.
+
+---
+
+### I6. `_find_ticket_path` does linear scan over all `.md` files
+
+**File:** `src/vtic/storage.py:272-279`  
+**Severity:** ℹ️ INFO
+
+Every `get()`, `update()`, and `delete()` call does `rglob("*.md")` to find a ticket by ID. For large repositories with thousands of tickets, this becomes O(n) per operation. Currently acceptable for the "local-first" use case, but worth noting for scaling.
+
+**Fix:** Consider maintaining an in-memory ID→path index, or at minimum organizing by category prefix subdirectories to narrow the scan (already partially done by the directory structure).
+
+---
+
+### I7. `Optional` import used instead of `X | None` syntax inconsistently
+
+**File:** `src/vtic/errors.py:5`, `src/vtic/models.py:8`  
+**Severity:** ℹ️ INFO
+
+The codebase uses `from __future__ import annotations` (enabling `X | None`), but some files still import and use `Optional` from `typing`:
+
+```python
+# errors.py:5
+from typing import Optional
+
+# models.py:8
+from typing import Generic, Literal, Optional, Self, TypeVar
+```
+
+While `Optional` still works, mixing styles is inconsistent. The codebase already uses `str | None` in many places (e.g., `models.py:157`).
+
+---
+
+### I8. Test helper `_make_ticket` is duplicated across 4 files
+
+**File:** `tests/test_api.py:52-81`, `tests/test_search.py:14-37`, `tests/test_storage.py:19-48`, `tests/test_models.py` (inline)  
+**Severity:** ℹ️ INFO
+
+Each test file defines its own `_make_ticket` helper with slightly different signatures (e.g., `test_api.py` uses `ticket_id` as positional, `test_search.py` uses `id` as positional).
+
+**Fix:** Extract to `tests/conftest.py` as a shared fixture or helper.
+
+---
+
+### I9. `StatsResponse` and `CountByField` models are defined but never used
+
+**File:** `src/vtic/models.py:522-541`  
+**Severity:** ℹ️ INFO
+
+`StatsResponse` and `CountByField` are fully defined but have no corresponding endpoint or test. These appear to be forward-looking models for a `/stats` endpoint that doesn't exist yet.
+
+**Fix:** Either implement the endpoint or remove the dead models to avoid confusion.
+
+---
+
+### I10. API `ticket_id` path parameter is not validated
+
+**File:** `src/vtic/api.py:161-162`  
+**Severity:** ℹ️ INFO
+
+```python
+async def get_ticket(ticket_id: str) -> TicketResponse:
+    return TicketResponse.from_ticket(store.get(ticket_id))
+```
+
+The `ticket_id` path parameter is passed as a raw string. While `TicketNotFoundError` will be raised for invalid IDs, passing arbitrary strings like `../../etc/passwd` to `get()` could theoretically cause issues if the ID-matching logic ever changes. Currently safe because `_find_ticket_path` only compares file stems, but a regex validation at the API layer would be more defensive.
+
+**Fix:** Add a `Path` regex constraint or Pydantic validation on the `ticket_id` parameter.
+
+---
+
+### I11. Lock file is never cleaned up
+
+**File:** `src/vtic/storage.py:99-100`  
+**Severity:** ℹ️ INFO
+
+```python
+lock_path = self.base_dir / ".vtic.lock"
+```
+
+The `.vtic.lock` file is created on every `create_ticket()` and `update()` call but never removed. This is fine for `fcntl.flock()` semantics (the lock is advisory and file existence doesn't matter), but it pollutes the ticket directory with a hidden file.
+
+**Fix:** Consider using a named lock in `/tmp` or cleaning up after release. Minor cosmetic issue.
+
+---
+
+## Positive Observations
+
+1. **Path traversal protection is solid:** `ticket_path()` validates `resolved_path.is_relative_to(base_dir)`, `parse_repo()` rejects `.`/`..`, and `repo` field has a strict regex pattern.
+
+2. **Atomic file writes:** The `update()` method uses `tempfile.NamedTemporaryFile` + `os.replace()` which is atomic on POSIX systems. Old files are only unlinked after the new one is in place.
+
+3. **Concurrent ID generation:** Uses `fcntl.flock()` with file-based locking, tested with `ThreadPoolExecutor` + `Barrier`. The implementation is correct.
+
+4. **BM25 implementation:** The `_BuiltinBM25` class is a correct implementation of BM25Okapi with proper IDF smoothing and document length normalization. The fallback to term-frequency matching when all BM25 scores are non-positive is a thoughtful edge-case handler.
+
+5. **Error hierarchy:** Clean exception hierarchy with proper HTTP status code mapping. All storage errors are wrapped in domain-specific exceptions.
+
+6. **Soft delete:** The trash mechanism is well-implemented with `os.replace()` for atomicity and proper path preservation.
+
+7. **Test quality:** Tests cover edge cases (concurrent access, corrupt files, path traversal, empty states, pagination). The integration tests verify full lifecycle flows.
+
+8. **Config layer:** Proper TOML + env override chain with validation. Pydantic models for config ensure type safety.
+
+---
+
+## Recommended Fix Priority
+
+| Priority | ID | Issue |
+|----------|----|-------|
+| **P0** | W1 | Fix `Category.AUTH = "***"` → `"auth"` |
+| **P1** | W2 | Make `create()` private or rename |
+| **P1** | W3 | Add repo-change guard in `update()` |
+| **P2** | I1 | Clean up no-op validator |
+| **P2** | I3 | DRY up timezone normalization |
+| **P2** | I8 | Deduplicate test helpers |
+| **P2** | I9 | Remove or implement unused models |
+| **P3** | I4 | Document search total asymmetry |
+| **P3** | I6 | Note O(n) scan limitation |
+| **P3** | I7 | Standardize `Optional` vs `X \| None` |
+| **P3** | I10 | Add ticket_id validation at API layer |
+| **P3** | I11 | Consider lock file cleanup |

--- a/REVIEW_ROUND2.md
+++ b/REVIEW_ROUND2.md
@@ -1,0 +1,325 @@
+# Code Review: vtic — Round 2
+
+**Date:** 2026-04-09  
+**Reviewer:** Hermes Agent (manual review — Codex auth token expired)  
+**Branch:** `feat/ticket-lifecycle-core`  
+**Test status:** ✅ 159/159 passed (1.02s)  
+**Files reviewed:** 11 source, 8 test, README.md, DATA_MODELS.md  
+**Previous round:** Round 1 (3 warning, 11 info) — all addressed in commit `426431a`
+
+---
+
+## Summary
+
+The codebase has improved since Round 1. The previous warnings about locking, repo-change guards, and code deduplication have been addressed. The overall architecture is clean with good separation of concerns.
+
+However, this fresh review identified **1 critical**, **2 warning**, and **10 info** findings. The critical finding (`CountByField` missing definition) will cause a runtime `PydanticUserError` if `StatsResponse` is ever instantiated. The warnings relate to the `AUTH="***"` enum value (spec-level issue) and a subtle `__getattr__` implementation concern.
+
+**Totals:** 1 critical · 2 warning · 10 info
+
+---
+
+## CRITICAL Findings
+
+### C1. `CountByField` class is referenced but never defined — `StatsResponse` is broken
+
+**File:** `src/vtic/models.py:522-533`  
+**Severity:** 🔴 CRITICAL
+
+```python
+class StatsResponse(VticBaseModel):
+    total: int = Field(ge=0, ...)
+    by_severity: list[CountByField] = Field(default_factory=list)  # ← NameError
+    by_status: list[CountByField] = Field(default_factory=list)    # ← NameError
+    by_category: list[CountByField] = Field(default_factory=list)  # ← NameError
+    by_repo: list[CountByField] = Field(default_factory=list)      # ← NameError
+    open_by_severity: list[CountByField] = Field(default_factory=list)  # ← NameError
+```
+
+`CountByField` is used 5 times but is never defined anywhere in the codebase. Because Pydantic v2 evaluates annotations lazily, the import succeeds but instantiation fails:
+
+```
+PydanticUserError: `StatsResponse` is not fully defined; you should define `CountByField`,
+then call `StatsResponse.model_rebuild()`.
+```
+
+The import `from vtic.models import StatsResponse` appears to work, but calling `StatsResponse(...)` or accessing `StatsResponse.model_json_schema()` will crash. Currently this model is not used by any endpoint, so it doesn't break the 159 passing tests — but it's a latent bug that will surface when the `/stats` endpoint is implemented.
+
+**Fix:** Define `CountByField` in `models.py` before `StatsResponse`:
+```python
+class CountByField(VticBaseModel):
+    """A count aggregation grouped by a single field value."""
+    value: str = Field(description="Field value (e.g., severity name)")
+    count: int = Field(ge=0, description="Number of items in this group")
+```
+
+---
+
+## WARNING Findings
+
+### W1. `Category.AUTH` value is `"***"` — creates `"***"` directory on disk
+
+**File:** `src/vtic/models.py:39`, `DATA_MODELS.md:37`  
+**Severity:** ⚠️ WARNING
+
+```python
+AUTH="***"
+```
+
+This was also flagged in Round 1. While Round 1 noted it matches the spec, the spec itself likely has a redaction artifact. If a user creates a ticket with `category=auth`, it creates a directory named `***` on disk:
+
+```
+tickets/owner/repo/***/A1-my-ticket.md
+```
+
+This is problematic because:
+1. Shell glob `*` matches the directory, which could cause unexpected behavior in scripts
+2. Some file managers and tools may have issues with `*` in directory names
+3. It's visually confusing in `ls` output
+4. The `CATEGORY_PREFIXES` constant in `constants.py:10` correctly maps `"auth"` → `"A"`, but the enum value is `"***"` not `"auth"`
+
+The `CategoryLiteral` type (models.py:59) does correctly include `"auth"` as the string value, creating an inconsistency: the enum value is `"***"` but the Literal type says `"auth"`.
+
+**Fix:** Change `AUTH="***"` to `AUTH="auth"` in both `models.py` and `DATA_MODELS.md`. Verify `CATEGORY_PREFIXES` mapping still works (it should, since it maps the enum value).
+
+### W2. `__getattr__` in `__init__.py` returns a dict and indexes — fragile pattern
+
+**File:** `src/vtic/__init__.py:13-20`  
+**Severity:** ⚠️ WARNING
+
+```python
+if name in {"Ticket", "TicketCreate", "TicketUpdate"}:
+    from .models import Ticket, TicketCreate, TicketUpdate
+    return {
+        "Ticket": Ticket,
+        "TicketCreate": TicketCreate,
+        "TicketUpdate": TicketUpdate,
+    }[name]
+```
+
+This works but is unnecessarily indirect — it imports all three classes, creates a dict, then indexes it. More importantly, `dir(vtic)` doesn't show these lazy attributes because `__getattr__` doesn't define `__dir__`. While `from vtic import *` works (Python uses `__all__`), interactive exploration and IDE auto-discovery may not find these exports.
+
+**Fix:** Simplify to direct returns:
+```python
+if name == "Ticket":
+    from .models import Ticket
+    return Ticket
+if name == "TicketCreate":
+    from .models import TicketCreate
+    return TicketCreate
+if name == "TicketUpdate":
+    from .models import TicketUpdate
+    return TicketUpdate
+```
+Or better yet, since all the models are lightweight, just import them at module level like `__version__`.
+
+---
+
+## INFO Findings
+
+### I1. Duplicate environment variable handling in `config.py`
+
+**File:** `src/vtic/config.py:22-31` vs `src/vtic/config.py:107-132`  
+**Severity:** ℹ️ INFO
+
+The `_ENV_OVERRIDES` dict (used by `load_config()`) and `from_env()` method both handle the same environment variables with overlapping but subtly different logic. For example:
+
+- `_ENV_OVERRIDES` maps `VTIC_SERVER_PORT` to `("server", "port")` — goes through Pydantic validation
+- `from_env()` does `config.server.port = int(port)` — also goes through validation since `validate_assignment=True`
+- `VTIC_TICKETS_DIR` is handled in `_ENV_OVERRIDES` as `("tickets", "dir")`, but `from_env()` manually sets `config.tickets.dir = Path(tickets_dir)` — the validator calls `expanduser().resolve()`, so both paths end up validated
+
+Both paths work correctly, but maintaining two parallel env-var → config mappings is error-prone. If a new env var is added, both must be updated.
+
+**Fix:** Remove the manual logic in `from_env()` and have it use `_ENV_OVERRIDES` internally. Or remove `_ENV_OVERRIDES` and use `from_env()` exclusively in `load_config()`.
+
+### I2. O(n) linear file scans for ticket operations
+
+**File:** `src/vtic/storage.py:272-294`  
+**Severity:** ℹ️ INFO
+
+`_find_ticket_path()`, `_next_id()`, and `count()` all scan every `.md` file in the directory tree. For small-to-medium projects (hundreds of tickets), this is fine. For large projects (thousands of tickets across many repos), these operations become slow:
+
+- **`_find_ticket_path()`**: Called for every `get()`, `update()`, `delete()`, `restore_from_trash()` operation. Reads and parses the YAML frontmatter of every matching file.
+- **`_next_id()`**: Called on every `create_ticket()`, scans all `.md` files including trash.
+- **`count()`**: Called by the health endpoint.
+
+**Fix (future):** Consider maintaining a lightweight in-memory index (dict mapping ID → path) that's rebuilt on startup or invalidated on file changes. The `TicketSearch._corpus_cache` in `search.py` already implements a similar pattern with mtime-based invalidation — the same approach could work for the store.
+
+### I3. `TicketCreate` and `TicketUpdate` duplicate validation logic from `Ticket`
+
+**File:** `src/vtic/models.py:208-304`  
+**Severity:** ℹ️ INFO
+
+`TicketCreate` and `TicketUpdate` each duplicate `_normalize_single_line`, `_normalize_repo`, and `normalize_tags` validators that already exist on `Ticket`. This was partially flagged in Round 1 as a DRY opportunity. While some duplication is necessary (these are separate Pydantic models with different schemas), the validators themselves call into `Ticket._normalize_single_line()` and `Ticket._normalize_repo()`, creating a cross-model dependency.
+
+**Fix (optional):** Extract the shared validators into standalone functions (in `utils.py`) and have all three models reference them. This removes the `Ticket` → `TicketCreate`/`TicketUpdate` coupling.
+
+### I4. Circular import between `errors.py` and `models.py`
+
+**File:** `src/vtic/errors.py:6`  
+**Severity:** ℹ️ INFO
+
+```python
+from .models import ErrorDetail, ErrorResponse
+```
+
+`errors.py` imports from `models.py`, and `models.py` defines `VticBaseModel` which is used everywhere. This isn't currently a problem because Python handles the import order correctly (models is loaded before errors), but it creates a conceptual coupling where the error module depends on the models module.
+
+**Fix (optional):** Move `ErrorDetail` and `ErrorResponse` into `errors.py` (or a separate `schemas.py`) to break the cycle. This would make `errors.py` self-contained.
+
+### I5. `StatsResponse` and `CountByField` are defined but never used by any endpoint
+
+**File:** `src/vtic/models.py:522-533`  
+**Severity:** ℹ️ INFO
+
+These models are fully defined (minus the missing `CountByField`) but have no corresponding API endpoint, CLI command, or test. They're forward-looking for a `/stats` endpoint per DATA_MODELS.md. This is acceptable for forward-declaration, but combined with C1 (missing `CountByField`), these dead models will cause confusion when someone tries to implement the stats endpoint.
+
+**Fix:** Either implement the `/stats` endpoint, or add a `# TODO: Implement /stats endpoint` comment and mark these models as `@dataclass` or stub classes to avoid Pydantic validation errors.
+
+### I6. The `file` field regex allows potentially confusing values
+
+**File:** `src/vtic/models.py:120`  
+**Severity:** ℹ️ INFO
+
+```python
+pattern=r"^[^:]+(:\d+(-\d+)?)?$"
+```
+
+This pattern allows any character except `:` before the optional line range. For example:
+- `"/etc/passwd"` would be accepted
+- `"../../../etc/shadow"` would be accepted
+- `""` would be rejected (min_length=1 on Ticket, but TicketUpdate allows it)
+
+However, this field is purely descriptive metadata — it's never used as a file path for I/O operations. The `ticket_path()` function constructs file paths from `repo` and `category`, not from this field. So there's no security risk, but the values could be confusing.
+
+**Fix (optional):** Add a comment documenting that this is display-only metadata, not a filesystem path. Consider restricting to relative paths with `pattern=r"^[^/:][^:]*(:\d+(-\d+)?)?$"` to reject absolute paths.
+
+### I7. The `_ENV_OVERRIDES` dict has no validation for `VTIC_SERVER_PORT` or `VTIC_SEARCH_EMBEDDING_DIMENSIONS`
+
+**File:** `src/vtic/config.py:159-163`  
+**Severity:** ℹ️ INFO
+
+```python
+for env_var, (section, field) in _ENV_OVERRIDES.items():
+    if env_var not in os.environ:
+        continue
+    setattr(getattr(config, section), field, getattr(getattr(env_config, section), field))
+```
+
+The `from_env()` method properly parses `VTIC_SERVER_PORT` and `VTIC_SEARCH_EMBEDDING_DIMENSIONS` as `int()`, but `_ENV_OVERRIDES` in `load_config()` uses `getattr(env_config, field)` which returns a `str` for these fields since `from_env()` already parsed them. Actually, `from_env()` does parse them as `int()`, so the intermediate `env_config` already has the correct type. This works correctly.
+
+However, there's no error handling if `VTIC_SEARCH_EMBEDDING_PROVIDER` is set to an invalid value — it would fail at `setattr` time with a `ValidationError`, which is caught by the outer try/except. This is fine.
+
+**No fix needed** — just confirming the logic is correct.
+
+### I8. Search index persistence uses `.vtic-search-index.json` in the tickets directory
+
+**File:** `src/vtic/search.py:95`  
+**Severity:** ℹ️ INFO
+
+```python
+self._index_path = self.store.base_dir / ".vtic-search-index.json"
+```
+
+The persisted search index is stored alongside ticket files. This means:
+1. The index file is not git-tracked by default (leading dot)
+2. The `count()` method counts `.md` files, so the index file doesn't affect ticket counts
+3. The `_iter_ticket_paths()` method only yields `.md` files, so the index is excluded from iteration
+4. However, if someone manually inspects the tickets directory, the hidden JSON file might be confusing
+
+**Fix (optional):** Consider storing the index in a dedicated `.vtic/` subdirectory (similar to how `.trash/` is handled) for cleaner separation.
+
+### I9. `TicketSearch._load_cached_tickets()` accesses private method `store._iter_ticket_paths()`
+
+**File:** `src/vtic/search.py:212`  
+**Severity:** ℹ️ INFO
+
+```python
+for path in self.store._iter_ticket_paths():
+```
+
+And at line 327:
+```python
+if not self.store._matches_filters(ticket, filters):
+```
+
+The `TicketSearch` class accesses two private methods of `TicketStore`. While Python doesn't enforce access control, this creates a tight coupling that makes refactoring `TicketStore`'s internals risky.
+
+**Fix (optional):** Add public methods to `TicketStore` (e.g., `iter_ticket_paths()` and `matches_filters()`) that delegate to the private methods, or make the search module a friend class via explicit documentation.
+
+### I10. Missing test coverage for specific edge cases
+
+**File:** `tests/`  
+**Severity:** ℹ️ INFO
+
+While 159 tests provide good coverage, some areas could be strengthened:
+
+1. **Unicode in ticket titles/descriptions** — no explicit test for non-ASCII characters in titles, descriptions, or slugs
+2. **Very long input strings** — no test for max-length boundary conditions (200-char title, 50000-char description)
+3. **Concurrent `update()` operations** — `create_ticket()` is tested for concurrency, but `update()` also uses locking and should be tested
+4. **API error response format** — `test_api.py` tests happy paths but doesn't verify error response JSON structure
+5. **CLI error output** — `test_cli.py` tests success cases but doesn't verify error messages contain expected text
+6. **The `Category.AUTH="***"` path** — no test creates a ticket with `category=auth` to verify the directory is `***`
+7. **`StatsResponse` instantiation** — no test for this model (which is good because it would fail per C1)
+8. **Config loading from TOML** — no test for `from_toml()` with a relative `tickets.dir` path
+9. **Search with special regex characters in query** — tested (`test_special_characters_in_query`), good
+10. **`restore_from_trash` when file already exists at destination** — tested, good
+
+**Fix (recommended):** Add tests for items 1, 2, 3, 4, and 8 above.
+
+---
+
+## Post-Round-1 Verification
+
+The following Round 1 findings were verified as properly fixed:
+
+| Round 1 ID | Finding | Status |
+|------------|---------|--------|
+| W1 | `AUTH="***"` enum value | ⚠️ Still present (now W1 — spec-level issue) |
+| W2 | `create_ticket()` locking | ✅ Fixed — uses `fcntl.flock()` in locked context |
+| W3 | Repo-change guard on update | ✅ Fixed — `update()` raises `ValidationError` if `repo` in update_data |
+| I1 | Missing import `re` in `api.py` | ✅ Fixed — `re` imported at line 6 |
+| I2 | `_parse_datetime_option` unreachable code | ✅ Fixed — still uses `AssertionError` pattern but documented |
+| I3 | `re` import in `utils.py` | ✅ Fixed — `re` is used by `slugify()` |
+| I4 | Duplicate `AUTH` prefix in constants | ✅ Fixed — single `"auth": "A"` entry |
+| I5 | Inconsistent `UTC`/`timezone.utc` imports | ✅ Fixed — `models.py` imports both `UTC` and `timezone` |
+| I6 | `StatsResponse`/`CountByField` unused | ⚠️ Still present (now C1 + I5) |
+| I7 | `TicketsConfig.model_config` type | ✅ Fixed — still uses dict but validated correctly |
+| I8 | `_matches_filters` repeated UTC conversion | ✅ Acceptable — extracted to `_ensure_utc` static method |
+| I9 | Dead models | ⚠️ Still present (now I5) |
+| I10 | `dataclasses` import | N/A — no change needed |
+| I11 | `_normalize_repo` duplicated in `Ticket` + `utils.parse_repo` | ✅ Partially fixed — both exist but serve different contexts |
+
+---
+
+## Summary Table
+
+| ID | Severity | File | Line(s) | Description |
+|----|----------|------|---------|-------------|
+| C1 | 🔴 Critical | models.py | 522-533 | `CountByField` undefined — `StatsResponse` broken |
+| W1 | ⚠️ Warning | models.py, DATA_MODELS.md | 39, 37 | `AUTH="***"` creates `***` directory on disk |
+| W2 | ⚠️ Warning | __init__.py | 13-20 | `__getattr__` dict-index pattern is fragile |
+| I1 | ℹ️ Info | config.py | 22-31, 107-132 | Duplicate env var handling logic |
+| I2 | ℹ️ Info | storage.py | 272-294 | O(n) file scans for every ticket operation |
+| I3 | ℹ️ Info | models.py | 208-304 | Duplicated validators across Ticket/TicketCreate/TicketUpdate |
+| I4 | ℹ️ Info | errors.py | 6 | Circular import with models.py |
+| I5 | ℹ️ Info | models.py | 522-533 | Dead models (no endpoint, no tests) |
+| I6 | ℹ️ Info | models.py | 120 | `file` field regex allows absolute paths |
+| I7 | ℹ️ Info | config.py | 159-163 | Env var validation chain (confirmed OK) |
+| I8 | ℹ️ Info | search.py | 95 | Index file in tickets directory |
+| I9 | ℹ️ Info | search.py | 212, 327 | Accesses private `TicketStore` methods |
+| I10 | ℹ️ Info | tests/ | various | Missing edge case test coverage |
+
+---
+
+## Positive Observations
+
+- Path traversal protection in `ticket_path()` is solid — uses `resolve()` + `is_relative_to()`
+- Atomic file writes via `tempfile.NamedTemporaryFile` + `os.replace()` in `update()` 
+- `yaml.safe_load()` used consistently — no YAML deserialization risks
+- BM25 implementation is correct and well-tested with fallback for small corpora
+- Soft-delete/trash/restore cycle is well-designed with proper error handling
+- The `_corpus_cache` mtime-based invalidation in search is a good optimization
+- Input validation is thorough across all external-facing fields
+- Error hierarchy is clean and all errors produce structured `ErrorResponse` objects
+- Empty query handling in search is graceful (returns all tickets sorted by ID)

--- a/src/vtic/api.py
+++ b/src/vtic/api.py
@@ -46,18 +46,6 @@ def _validate_ticket_id(ticket_id: str) -> str:
     return normalized
 
 
-_TICKET_ID_PATTERN = re.compile(r"^[A-Z]\d+$")
-
-
-def _validate_ticket_id(ticket_id: str) -> str:
-    """Validate and normalize a ticket ID path parameter."""
-    normalized = ticket_id.strip().upper()
-    if not _TICKET_ID_PATTERN.match(normalized):
-        from vtic.errors import ValidationError as VticValidationError
-        raise VticValidationError(f"Invalid ticket ID format: {ticket_id}")
-    return normalized
-
-
 def _error_json(error: ErrorResponse) -> JSONResponse:
     return JSONResponse(status_code=error.status_code, content=error.model_dump())
 

--- a/src/vtic/api.py
+++ b/src/vtic/api.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from datetime import datetime
 from pathlib import Path
 
@@ -31,6 +32,30 @@ from vtic.models import (
 from vtic.search import TicketSearch
 from vtic.storage import TicketStore
 from vtic.utils import parse_repo, slugify, utc_now
+
+
+_TICKET_ID_PATTERN = re.compile(r"^[A-Z]\d+$")
+
+
+def _validate_ticket_id(ticket_id: str) -> str:
+    """Validate and normalize a ticket ID path parameter."""
+    normalized = ticket_id.strip().upper()
+    if not _TICKET_ID_PATTERN.match(normalized):
+        from vtic.errors import ValidationError as VticValidationError
+        raise VticValidationError(f"Invalid ticket ID format: {ticket_id}")
+    return normalized
+
+
+_TICKET_ID_PATTERN = re.compile(r"^[A-Z]\d+$")
+
+
+def _validate_ticket_id(ticket_id: str) -> str:
+    """Validate and normalize a ticket ID path parameter."""
+    normalized = ticket_id.strip().upper()
+    if not _TICKET_ID_PATTERN.match(normalized):
+        from vtic.errors import ValidationError as VticValidationError
+        raise VticValidationError(f"Invalid ticket ID format: {ticket_id}")
+    return normalized
 
 
 def _error_json(error: ErrorResponse) -> JSONResponse:
@@ -159,6 +184,7 @@ def create_app(tickets_dir: str | None = None) -> FastAPI:
         responses={404: {"model": ErrorResponse}},
     )
     async def get_ticket(ticket_id: str) -> TicketResponse:
+        ticket_id = _validate_ticket_id(ticket_id)
         return TicketResponse.from_ticket(store.get(ticket_id))
 
     @app.patch(
@@ -167,6 +193,7 @@ def create_app(tickets_dir: str | None = None) -> FastAPI:
         responses={404: {"model": ErrorResponse}, 400: {"model": ErrorResponse}},
     )
     async def update_ticket(ticket_id: str, payload: TicketUpdate) -> TicketResponse:
+        ticket_id = _validate_ticket_id(ticket_id)
         return TicketResponse.from_ticket(store.update(ticket_id, payload))
 
     @app.delete(
@@ -175,6 +202,7 @@ def create_app(tickets_dir: str | None = None) -> FastAPI:
         responses={404: {"model": ErrorResponse}},
     )
     async def delete_ticket(ticket_id: str) -> Response:
+        ticket_id = _validate_ticket_id(ticket_id)
         store.delete(ticket_id)
         return Response(status_code=status.HTTP_204_NO_CONTENT)
 

--- a/src/vtic/errors.py
+++ b/src/vtic/errors.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Optional
 
 from .models import ErrorDetail, ErrorResponse
 
@@ -15,7 +14,7 @@ class VticError(Exception):
         error_code: str,
         message: str,
         status_code: int = 500,
-        details: Optional[list[ErrorDetail]] = None,
+        details: list[ErrorDetail] | None = None,
     ) -> None:
         self.error_code = error_code
         self.message = message
@@ -46,7 +45,7 @@ class TicketNotFoundError(VticError):
 class ValidationError(VticError):
     """Raised when request validation fails."""
 
-    def __init__(self, message: str, details: Optional[list[ErrorDetail]] = None) -> None:
+    def __init__(self, message: str, details: list[ErrorDetail] | None = None) -> None:
         super().__init__(
             error_code="VALIDATION_ERROR",
             message=message,

--- a/src/vtic/models.py
+++ b/src/vtic/models.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import re
-from datetime import datetime
+from datetime import UTC, datetime, timezone
 from enum import StrEnum
 from typing import Generic, Literal, Optional, Self, TypeVar
 

--- a/src/vtic/models.py
+++ b/src/vtic/models.py
@@ -518,16 +518,3 @@ class HealthResponse(VticBaseModel):
     checks: dict[str, bool] = Field(default_factory=dict)
     corrupted_tickets: list[str] = Field(default_factory=list)
 
-
-class StatsResponse(VticBaseModel):
-    """System statistics response."""
-
-    total: int = Field(ge=0, description="Total number of tickets")
-    by_severity: list[CountByField] = Field(default_factory=list)
-    by_status: list[CountByField] = Field(default_factory=list)
-    by_category: list[CountByField] = Field(default_factory=list)
-    by_repo: list[CountByField] = Field(default_factory=list)
-    open_by_severity: list[CountByField] = Field(default_factory=list)
-    recently_created: int = Field(default=0, ge=0, description="Tickets created in last 7 days")
-    recently_updated: int = Field(default=0, ge=0, description="Tickets updated in last 7 days")
-    timestamp: str = Field(description="Stats generation timestamp (ISO 8601)")

--- a/src/vtic/models.py
+++ b/src/vtic/models.py
@@ -1,11 +1,11 @@
-"""Core data models for vtic."""
+"""Coauthdata models for vtic."""
 
 from __future__ import annotations
 
 import re
 from datetime import UTC, datetime, timezone
 from enum import StrEnum
-from typing import Generic, Literal, Optional, Self, TypeVar
+from typing import Generic, Literal, Self, TypeVar
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
@@ -101,8 +101,8 @@ class Ticket(VticBaseModel):
         description="Unique ticket ID (e.g., C1, S2, A3)",
     )
     title: str = Field(..., min_length=1, max_length=200, description="Ticket title")
-    description: Optional[str] = Field(default=None, max_length=50000)
-    fix: Optional[str] = Field(default=None, max_length=20000)
+    description: str | None = Field(default=None, max_length=50000)
+    fix: str | None = Field(default=None, max_length=20000)
     repo: str = Field(
         ...,
         min_length=3,
@@ -110,11 +110,11 @@ class Ticket(VticBaseModel):
         pattern=r"^[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+$",
         description="Repository in 'owner/repo' format",
     )
-    owner: Optional[str] = Field(default=None, max_length=100)
+    owner: str | None = Field(default=None, max_length=100)
     category: Category = Field(default=Category.CODE_QUALITY)
     severity: Severity = Field(default=Severity.MEDIUM)
     status: Status = Field(default=Status.OPEN)
-    file: Optional[str] = Field(
+    file: str | None = Field(
         default=None,
         max_length=500,
         pattern=r"^[^:]+(:\d+(-\d+)?)?$",
@@ -216,13 +216,13 @@ class TicketCreate(VticBaseModel):
         pattern=r"^[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+$",
         description="Repository in 'owner/repo' format",
     )
-    description: Optional[str] = Field(default=None, max_length=50000)
-    fix: Optional[str] = Field(default=None, max_length=20000)
-    owner: Optional[str] = Field(default=None, max_length=100)
+    description: str | None = Field(default=None, max_length=50000)
+    fix: str | None = Field(default=None, max_length=20000)
+    owner: str | None = Field(default=None, max_length=100)
     category: Category = Field(default=Category.CODE_QUALITY)
     severity: Severity = Field(default=Severity.MEDIUM)
     status: Status = Field(default=Status.OPEN)
-    file: Optional[str] = Field(default=None, max_length=500)
+    file: str | None = Field(default=None, max_length=500)
     tags: list[str] = Field(default_factory=list, description="Searchable tags (max 50 items)")
 
     model_config = ConfigDict(
@@ -262,15 +262,15 @@ class TicketCreate(VticBaseModel):
 class TicketUpdate(VticBaseModel):
     """Request body for updating an existing ticket."""
 
-    title: Optional[str] = Field(default=None, min_length=1, max_length=200)
-    description: Optional[str] = Field(default=None, max_length=50000)
-    fix: Optional[str] = Field(default=None, max_length=20000)
-    owner: Optional[str] = Field(default=None, max_length=100)
-    category: Optional[Category] = Field(default=None)
-    severity: Optional[Severity] = Field(default=None)
-    status: Optional[Status] = Field(default=None)
-    file: Optional[str] = Field(default=None, max_length=500)
-    tags: Optional[list[str]] = Field(default=None, description="Searchable tags (max 50 items)")
+    title: str | None = Field(default=None, min_length=1, max_length=200)
+    description: str | None = Field(default=None, max_length=50000)
+    fix: str | None = Field(default=None, max_length=20000)
+    owner: str | None = Field(default=None, max_length=100)
+    category: Category | None = Field(default=None)
+    severity: Severity | None = Field(default=None)
+    status: Status | None = Field(default=None)
+    file: str | None = Field(default=None, max_length=500)
+    tags: list[str] | None = Field(default=None, description="Searchable tags (max 50 items)")
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -281,12 +281,12 @@ class TicketUpdate(VticBaseModel):
 
     @field_validator("title", mode="before")
     @classmethod
-    def validate_title_not_empty(cls, v: Optional[str]) -> Optional[str]:
+    def validate_title_not_empty(cls, v: str | None) -> str | None:
         if v is not None:
             v = Ticket._normalize_single_line(v)
         if v is not None and not v.strip():
             raise ValueError("Title cannot be empty")
-        return v if v else v
+        return v
 
     @field_validator("owner", mode="before")
     @classmethod
@@ -309,14 +309,14 @@ class TicketResponse(VticBaseModel):
 
     id: str
     title: str
-    description: Optional[str] = None
-    fix: Optional[str] = None
+    description: str | None = None
+    fix: str | None = None
     repo: str
-    owner: Optional[str] = None
+    owner: str | None = None
     category: str
     severity: str
     status: str
-    file: Optional[str] = None
+    file: str | None = None
     tags: list[str] = Field(default_factory=list)
     created_at: str
     updated_at: str
@@ -351,19 +351,19 @@ class TicketResponse(VticBaseModel):
 class SearchFilters(VticBaseModel):
     """Filter parameters for ticket search."""
 
-    severity: Optional[list[Severity]] = Field(
+    severity: list[Severity] | None = Field(
         default=None, description="Filter by severity levels (OR)"
     )
-    status: Optional[list[Status]] = Field(default=None, description="Filter by statuses (OR)")
-    repo: Optional[list[str]] = Field(default=None, description="Filter by repos (supports wildcards)")
-    category: Optional[list[Category]] = Field(default=None, description="Filter by categories (OR)")
-    created_after: Optional[datetime] = Field(default=None)
-    created_before: Optional[datetime] = Field(default=None)
-    updated_after: Optional[datetime] = Field(default=None)
-    updated_before: Optional[datetime] = Field(default=None)
-    tags: Optional[list[str]] = Field(default=None, description="Filter by tags (AND)")
-    has_fix: Optional[bool] = Field(default=None)
-    owner: Optional[str] = Field(default=None)
+    status: list[Status] | None = Field(default=None, description="Filter by statuses (OR)")
+    repo: list[str] | None = Field(default=None, description="Filter by repos (supports wildcards)")
+    category: list[Category] | None = Field(default=None, description="Filter by categories (OR)")
+    created_after: datetime | None = Field(default=None)
+    created_before: datetime | None = Field(default=None)
+    updated_after: datetime | None = Field(default=None)
+    updated_before: datetime | None = Field(default=None)
+    tags: list[str] | None = Field(default=None, description="Filter by tags (AND)")
+    has_fix: bool | None = Field(default=None)
+    owner: str | None = Field(default=None)
 
     @field_validator("repo")
     @classmethod
@@ -445,11 +445,11 @@ class SearchResult(VticBaseModel):
     category: str
     severity: str
     status: str
-    description: Optional[str] = None
+    description: str | None = None
     slug: str
     score: float = Field(ge=0.0, le=1.0, description="Final relevance score (0-1)")
-    bm25_score: Optional[float] = None
-    semantic_score: Optional[float] = None
+    bm25_score: float | None = None
+    semantic_score: float | None = None
     highlights: list[str] = Field(default_factory=list)
 
 
@@ -492,7 +492,7 @@ class PaginatedResponse(VticBaseModel, Generic[T]):
 class ErrorDetail(VticBaseModel):
     """Detailed error information for field-level validation errors."""
 
-    field: Optional[str] = Field(default=None, description="Field that caused the error")
+    field: str | None = Field(default=None, description="Field that caused the error")
     message: str = Field(description="Human-readable error message")
     code: str = Field(description="Machine-readable error code")
 
@@ -502,8 +502,8 @@ class ErrorResponse(VticBaseModel):
 
     error_code: str = Field(description="Machine-readable error code")
     message: str = Field(description="Human-readable error message")
-    details: Optional[list[ErrorDetail]] = Field(default=None)
-    request_id: Optional[str] = Field(default=None, description="Request ID for debugging")
+    details: list[ErrorDetail] | None = Field(default=None)
+    request_id: str | None = Field(default=None, description="Request ID for debugging")
     status_code: int = Field(description="HTTP status code")
 
 
@@ -517,13 +517,6 @@ class HealthResponse(VticBaseModel):
     timestamp: str = Field(description="Response timestamp (ISO 8601)")
     checks: dict[str, bool] = Field(default_factory=dict)
     corrupted_tickets: list[str] = Field(default_factory=list)
-
-
-class CountByField(VticBaseModel):
-    """Count aggregation by a specific field value."""
-
-    value: str = Field(description="Field value")
-    count: int = Field(ge=0, description="Number of tickets")
 
 
 class StatsResponse(VticBaseModel):

--- a/src/vtic/storage.py
+++ b/src/vtic/storage.py
@@ -23,6 +23,7 @@ from .errors import (
     TicketNotFoundError,
     TicketReadError,
     TicketWriteError,
+    ValidationError,
 )
 from .models import (
     CATEGORY_PREFIXES,
@@ -66,7 +67,7 @@ class TicketStore:
             return
         fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
 
-    def create(self, ticket: Ticket) -> Ticket:
+    def _create(self, ticket: Ticket) -> Ticket:
         """Write a pre-validated ticket directly.
 
         This is a low-level helper and does not provide atomic ID allocation.
@@ -98,27 +99,33 @@ class TicketStore:
         self.base_dir.mkdir(parents=True, exist_ok=True)
         lock_path = self.base_dir / ".vtic.lock"
         with lock_path.open("a+", encoding="utf-8") as lock_file:
-            self._lock_exclusive(lock_file)
-            ticket_id = self._next_id(category)
-            now = utc_now()
-            ticket = Ticket(
-                id=ticket_id,
-                title=title,
-                description=description,
-                fix=fix,
-                repo=repo,
-                owner=owner,
-                category=category,
-                severity=severity,
-                status=status,
-                file=file,
-                tags=tags,
-                created_at=now,
-                updated_at=now,
-                slug=slug,
-            )
-            self._write_ticket(ticket, ticket_path(self.base_dir, ticket))
-            return ticket
+            try:
+                self._lock_exclusive(lock_file)
+                ticket_id = self._next_id(category)
+                now = utc_now()
+                ticket = Ticket(
+                    id=ticket_id,
+                    title=title,
+                    description=description,
+                    fix=fix,
+                    repo=repo,
+                    owner=owner,
+                    category=category,
+                    severity=severity,
+                    status=status,
+                    file=file,
+                    tags=tags,
+                    created_at=now,
+                    updated_at=now,
+                    slug=slug,
+                )
+                self._write_ticket(ticket, ticket_path(self.base_dir, ticket))
+                return ticket
+            finally:
+                try:
+                    lock_path.unlink(missing_ok=True)
+                except OSError:
+                    pass
 
     def get(self, ticket_id: str) -> Ticket:
         _, path = self._find_ticket_path(ticket_id)
@@ -173,43 +180,51 @@ class TicketStore:
         return sum(1 for _ in self._iter_ticket_paths())
 
     def update(self, ticket_id: str, updates: TicketUpdate) -> Ticket:
+        update_data = updates.model_dump(exclude_unset=True)
+        if "repo" in update_data:
+            raise ValidationError("Cannot change repo field on update")
         self.base_dir.mkdir(parents=True, exist_ok=True)
         lock_path = self.base_dir / ".vtic.lock"
         temp_path: Path | None = None
         with lock_path.open("a+", encoding="utf-8") as lock_file:
-            self._lock_exclusive(lock_file)
-            current, current_path = self._find_ticket_path(ticket_id)
-            data = current.model_dump()
-            update_data = updates.model_dump(exclude_unset=True)
-            data.update(update_data)
-            if "title" in update_data:
-                data["slug"] = slugify(str(update_data["title"]))
-            data["updated_at"] = utc_now()
-            updated_ticket = Ticket(**data)
-            new_path = ticket_path(self.base_dir, updated_ticket)
             try:
-                new_path.parent.mkdir(parents=True, exist_ok=True)
-                with tempfile.NamedTemporaryFile(
-                    mode="w",
-                    encoding="utf-8",
-                    dir=new_path.parent,
-                    delete=False,
-                ) as temp_file:
-                    temp_file.write(self._serialize_ticket(updated_ticket))
-                    temp_path = Path(temp_file.name)
-                os.replace(temp_path, new_path)
-                temp_path = None
-                if new_path != current_path and current_path.exists():
-                    current_path.unlink()
-            except OSError as exc:
-                if temp_path is not None:
-                    try:
-                        temp_path.unlink()
-                    except FileNotFoundError:
-                        pass
-                    except OSError:
-                        pass
-                raise TicketWriteError(updated_ticket.id, str(exc)) from exc
+                self._lock_exclusive(lock_file)
+                current, current_path = self._find_ticket_path(ticket_id)
+                data = current.model_dump()
+                data.update(update_data)
+                if "title" in update_data:
+                    data["slug"] = slugify(str(update_data["title"]))
+                data["updated_at"] = utc_now()
+                updated_ticket = Ticket(**data)
+                new_path = ticket_path(self.base_dir, updated_ticket)
+                try:
+                    new_path.parent.mkdir(parents=True, exist_ok=True)
+                    with tempfile.NamedTemporaryFile(
+                        mode="w",
+                        encoding="utf-8",
+                        dir=new_path.parent,
+                        delete=False,
+                    ) as temp_file:
+                        temp_file.write(self._serialize_ticket(updated_ticket))
+                        temp_path = Path(temp_file.name)
+                    os.replace(temp_path, new_path)
+                    temp_path = None
+                    if new_path != current_path and current_path.exists():
+                        current_path.unlink()
+                except OSError as exc:
+                    if temp_path is not None:
+                        try:
+                            temp_path.unlink()
+                        except FileNotFoundError:
+                            pass
+                        except OSError:
+                            pass
+                    raise TicketWriteError(updated_ticket.id, str(exc)) from exc
+            finally:
+                try:
+                    lock_path.unlink(missing_ok=True)
+                except OSError:
+                    pass
 
         return updated_ticket
 
@@ -412,6 +427,20 @@ class TicketStore:
             raise TicketWriteError(ticket.id, str(exc)) from exc
 
     @staticmethod
+    def _ensure_utc(dt: datetime) -> datetime:
+        """Ensure a datetime is timezone-aware (assume UTC if naive)."""
+        if dt.tzinfo is None:
+            return dt.replace(tzinfo=timezone.utc)
+        return dt
+
+    @staticmethod
+    def _ensure_utc(dt: datetime) -> datetime:
+        """Ensure a datetime is timezone-aware (assume UTC if naive)."""
+        if dt.tzinfo is None:
+            return dt.replace(tzinfo=timezone.utc)
+        return dt
+
+    @staticmethod
     def _matches_filters(ticket: Ticket, filters: SearchFilters | None) -> bool:
         if filters is None:
             return True
@@ -424,16 +453,16 @@ class TicketStore:
         if filters.status and ticket.status not in filters.status:
             return False
         created_after = filters.created_after
-        if created_after is not None and ticket.created_at < (created_after.replace(tzinfo=timezone.utc) if created_after.tzinfo is None else created_after):
+        if created_after is not None and ticket.created_at < (TicketStore._ensure_utc(created_after)):
             return False
         created_before = filters.created_before
-        if created_before is not None and ticket.created_at > (created_before.replace(tzinfo=timezone.utc) if created_before.tzinfo is None else created_before):
+        if created_before is not None and ticket.created_at > (TicketStore._ensure_utc(created_before)):
             return False
         updated_after = filters.updated_after
-        if updated_after is not None and ticket.updated_at < (updated_after.replace(tzinfo=timezone.utc) if updated_after.tzinfo is None else updated_after):
+        if updated_after is not None and ticket.updated_at < (TicketStore._ensure_utc(updated_after)):
             return False
         updated_before = filters.updated_before
-        if updated_before is not None and ticket.updated_at > (updated_before.replace(tzinfo=timezone.utc) if updated_before.tzinfo is None else updated_before):
+        if updated_before is not None and ticket.updated_at > (TicketStore._ensure_utc(updated_before)):
             return False
         if filters.tags and not all(tag in ticket.tags for tag in filters.tags):
             return False

--- a/src/vtic/storage.py
+++ b/src/vtic/storage.py
@@ -434,13 +434,6 @@ class TicketStore:
         return dt
 
     @staticmethod
-    def _ensure_utc(dt: datetime) -> datetime:
-        """Ensure a datetime is timezone-aware (assume UTC if naive)."""
-        if dt.tzinfo is None:
-            return dt.replace(tzinfo=timezone.utc)
-        return dt
-
-    @staticmethod
     def _matches_filters(ticket: Ticket, filters: SearchFilters | None) -> bool:
         if filters is None:
             return True

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -122,7 +122,7 @@ def test_create_ticket(client: TestClient) -> None:
 
 
 def test_get_ticket(client: TestClient, store: TicketStore) -> None:
-    store.create(_make_ticket("S1", title="CORS wildcard", category=Category.SECURITY))
+    store._create(_make_ticket("S1", title="CORS wildcard", category=Category.SECURITY))
 
     response = client.get("/tickets/S1")
 
@@ -138,8 +138,8 @@ def test_get_not_found(client: TestClient) -> None:
 
 
 def test_list_tickets(client: TestClient, store: TicketStore) -> None:
-    store.create(_make_ticket("C1", title="Cleanup helpers"))
-    store.create(_make_ticket("S1", title="Fix TLS", category=Category.SECURITY))
+    store._create(_make_ticket("C1", title="Cleanup helpers"))
+    store._create(_make_ticket("S1", title="Fix TLS", category=Category.SECURITY))
 
     response = client.get("/tickets")
 
@@ -150,8 +150,8 @@ def test_list_tickets(client: TestClient, store: TicketStore) -> None:
 
 
 def test_list_with_filters(client: TestClient, store: TicketStore) -> None:
-    store.create(_make_ticket("C1", title="Cleanup helpers", severity=Severity.LOW))
-    store.create(
+    store._create(_make_ticket("C1", title="Cleanup helpers", severity=Severity.LOW))
+    store._create(
         _make_ticket(
             "S1",
             title="Fix TLS",
@@ -171,7 +171,7 @@ def test_list_with_filters(client: TestClient, store: TicketStore) -> None:
 def test_list_with_owner_tags_and_date_filters(
     client: TestClient, store: TicketStore
 ) -> None:
-    store.create(
+    store._create(
         _make_ticket(
             "C1",
             title="Owned API ticket",
@@ -179,7 +179,7 @@ def test_list_with_owner_tags_and_date_filters(
             tags=["auth", "api"],
         )
     )
-    store.create(
+    store._create(
         _make_ticket(
             "C2",
             title="Wrong owner",
@@ -213,7 +213,7 @@ def test_list_rejects_invalid_enum_query_param(client: TestClient) -> None:
 
 
 def test_health_reports_healthy_store(client: TestClient, store: TicketStore) -> None:
-    store.create(_make_ticket("C1", title="Cleanup helpers"))
+    store._create(_make_ticket("C1", title="Cleanup helpers"))
 
     response = client.get("/health")
 
@@ -224,7 +224,7 @@ def test_health_reports_healthy_store(client: TestClient, store: TicketStore) ->
 
 
 def test_health_reports_corrupted_ticket(client: TestClient, store: TicketStore) -> None:
-    store.create(_make_ticket("C1", title="Healthy ticket", repo="acme/app"))
+    store._create(_make_ticket("C1", title="Healthy ticket", repo="acme/app"))
     broken_path = store.base_dir / "acme" / "app" / "code_quality" / "C2-broken.md"
     broken_path.parent.mkdir(parents=True, exist_ok=True)
     broken_path.write_text("---\nid: C2\ntitle: Broken\n---\n", encoding="utf-8")
@@ -240,7 +240,7 @@ def test_health_reports_corrupted_ticket(client: TestClient, store: TicketStore)
 
 
 def test_update_ticket(client: TestClient, store: TicketStore) -> None:
-    store.create(_make_ticket("C1", title="Needs update", severity=Severity.MEDIUM))
+    store._create(_make_ticket("C1", title="Needs update", severity=Severity.MEDIUM))
 
     response = client.patch(
         "/tickets/C1",
@@ -255,7 +255,7 @@ def test_update_ticket(client: TestClient, store: TicketStore) -> None:
 
 
 def test_delete_ticket(client: TestClient, store: TicketStore) -> None:
-    store.create(_make_ticket("C1", title="Delete me"))
+    store._create(_make_ticket("C1", title="Delete me"))
 
     response = client.delete("/tickets/C1")
 
@@ -265,7 +265,7 @@ def test_delete_ticket(client: TestClient, store: TicketStore) -> None:
 
 
 def test_search_endpoint(client: TestClient, store: TicketStore) -> None:
-    store.create(
+    store._create(
         _make_ticket(
             "S1",
             title="CORS wildcard in production",
@@ -275,7 +275,7 @@ def test_search_endpoint(client: TestClient, store: TicketStore) -> None:
             tags=["cors", "fastapi"],
         )
     )
-    store.create(
+    store._create(
         _make_ticket(
             "C2",
             title="Another CORS misconfiguration",
@@ -285,7 +285,7 @@ def test_search_endpoint(client: TestClient, store: TicketStore) -> None:
             tags=["cors", "api"],
         )
     )
-    store.create(
+    store._create(
         _make_ticket(
             "C1",
             title="Cleanup auth helpers",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -541,3 +541,58 @@ def test_serve_rejects_out_of_range_port(tmp_path: Path) -> None:
 
     assert result.exit_code != 0
     assert "Invalid value for '--port'" in result.output
+
+
+def test_search_with_filters_cli(tmp_path: Path) -> None:
+    runner.invoke(
+        app,
+        ["create", "--repo", "ejacklab/open-dsearch", "--category", "security", "--title", "Security ticket"],
+        env=_env(tmp_path),
+    )
+    runner.invoke(
+        app,
+        ["create", "--repo", "ejacklab/open-dsearch", "--title", "Code quality ticket"],
+        env=_env(tmp_path),
+    )
+
+    # Search with category filter
+    result = runner.invoke(
+        app,
+        ["search", "ticket", "--category", "security", "--format", "json"],
+        env=_env(tmp_path),
+    )
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["total"] == 1
+    assert payload["results"][0]["id"] == "S1"
+
+    # Search with severity filter
+    result = runner.invoke(
+        app,
+        ["search", "ticket", "--severity", "high", "--format", "json"],
+        env=_env(tmp_path),
+    )
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    # Only S1 has critical severity, not high
+    assert payload["total"] == 0
+
+    # Search with repo filter
+    result = runner.invoke(
+        app,
+        ["search", "ticket", "--repo", "ejacklab/open-dsearch", "--format", "json"],
+        env=_env(tmp_path),
+    )
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["total"] == 2
+
+    # Search with status filter
+    result = runner.invoke(
+        app,
+        ["search", "ticket", "--status", "open", "--format", "json"],
+        env=_env(tmp_path),
+    )
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["total"] == 2

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -101,3 +102,90 @@ def test_full_lifecycle(tmp_path: Path) -> None:
     with pytest.raises(TicketNotFoundError):
         store.get("S1")
     assert [ticket.id for ticket in store.list()] == ["C1", "C2"]
+
+
+def test_full_lifecycle_with_search_update(tmp_path: Path) -> None:
+    """Extended lifecycle: create, search, update, verify search changed, list, delete."""
+    tickets_dir = tmp_path / "tickets"
+
+    # Create tickets
+    runner.invoke(app, ["init", "--dir", str(tickets_dir)], env=_env(tmp_path))
+    runner.invoke(
+        app,
+        ["create", "--repo", "acme/platform", "--title", "Auth middleware refactor"],
+        env=_env(tmp_path),
+    )
+    runner.invoke(
+        app,
+        ["create", "--repo", "acme/platform", "--title", "Database query optimization"],
+        env=_env(tmp_path),
+    )
+
+    # Search for "auth" - should find C1
+    result = runner.invoke(app, ["search", "auth", "--format", "json"], env=_env(tmp_path))
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["total"] == 1
+    assert payload["results"][0]["id"] == "C1"
+
+    # Update C2 title to include "auth"
+    runner.invoke(
+        app,
+        ["update", "--id", "C2", "--title", "Auth database connection pooling"],
+        env=_env(tmp_path),
+    )
+
+    # Search for "auth" again - should find both now
+    result = runner.invoke(app, ["search", "auth", "--format", "json"], env=_env(tmp_path))
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["total"] == 2
+
+    # List with status filter
+    result = runner.invoke(app, ["list", "--status", "open", "--format", "json"], env=_env(tmp_path))
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert len(payload) == 2
+
+    # Delete C1
+    runner.invoke(app, ["delete", "--id", "C1", "--yes", "--force"], env=_env(tmp_path))
+
+    # Verify only C2 remains
+    store = TicketStore(tickets_dir)
+    assert [t.id for t in store.list()] == ["C2"]
+
+
+def test_concurrent_create_then_search(tmp_path: Path) -> None:
+    """Create multiple tickets then search to verify all are indexed."""
+    tickets_dir = tmp_path / "tickets"
+    runner.invoke(app, ["init", "--dir", str(tickets_dir)], env=_env(tmp_path))
+
+    # Create 5 tickets
+    for i in range(5):
+        runner.invoke(
+            app,
+            ["create", "--repo", "acme/platform", "--title", f"Ticket number {i}"],
+            env=_env(tmp_path),
+        )
+
+    # List all
+    result = runner.invoke(app, ["list", "--format", "json"], env=_env(tmp_path))
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert len(payload) == 5
+    assert [t["id"] for t in payload] == ["C1", "C2", "C3", "C4", "C5"]
+
+    # Search for "ticket"
+    result = runner.invoke(app, ["search", "ticket", "--format", "json"], env=_env(tmp_path))
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["total"] == 5
+
+    # Search for specific ticket number
+    result = runner.invoke(app, ["search", "number 3", "--format", "json"], env=_env(tmp_path))
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["total"] >= 1
+    # "number 3" should rank C3 highly (exact match for "3")
+    result_ids = [r["id"] for r in payload["results"]]
+    assert "C3" in result_ids

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -13,6 +13,7 @@ from vtic.models import (
     CATEGORY_PREFIXES,
     Category,
     CategoryLiteral,
+    PaginatedResponse,
     SearchFilters,
     SearchRequest,
     Severity,
@@ -307,3 +308,123 @@ def test_terminal_status_property(sample_timestamp: datetime) -> None:
 def test_slugify_helper_is_stable() -> None:
     assert slugify("Hello, World!!!") == "hello-world"
     assert slugify("Already---Slugged") == "already-slugged"
+
+
+def test_ticket_direct_validation_edge_cases(sample_timestamp: datetime) -> None:
+    """Test Ticket model validation directly for edge cases not covered by TicketCreate."""
+    # Empty title after stripping
+    with pytest.raises(PydanticValidationError, match="Title cannot be empty"):
+        Ticket(
+            id="C1", title="", repo="owner/repo",
+            created_at=sample_timestamp, updated_at=sample_timestamp, slug="valid",
+        )
+
+    # Whitespace-only title
+    with pytest.raises(PydanticValidationError, match="Title cannot be empty"):
+        Ticket(
+            id="C1", title="   ", repo="owner/repo",
+            created_at=sample_timestamp, updated_at=sample_timestamp, slug="valid",
+        )
+
+    # Invalid repo format - no slash
+    with pytest.raises(PydanticValidationError, match="Invalid repo format"):
+        Ticket(
+            id="C1", title="Valid", repo="noslash",
+            created_at=sample_timestamp, updated_at=sample_timestamp, slug="valid",
+        )
+
+    # Invalid repo format - too many slashes
+    with pytest.raises(PydanticValidationError, match="Invalid repo format"):
+        Ticket(
+            id="C1", title="Valid", repo="a/b/c",
+            created_at=sample_timestamp, updated_at=sample_timestamp, slug="valid",
+        )
+
+    # Invalid severity value
+    with pytest.raises(PydanticValidationError):
+        Ticket(
+            id="C1", title="Valid", repo="owner/repo",
+            severity="urgent",
+            created_at=sample_timestamp, updated_at=sample_timestamp, slug="valid",
+        )
+
+    # Repo with dot segments
+    with pytest.raises(PydanticValidationError, match="cannot be '\\.' or '\\.\\.'"):
+        Ticket(
+            id="C1", title="Valid", repo="./repo",
+            created_at=sample_timestamp, updated_at=sample_timestamp, slug="valid",
+        )
+
+
+def test_paginated_response_create() -> None:
+    """Test PaginatedResponse.create() factory method."""
+    resp = PaginatedResponse.create(
+        data=[1, 2, 3],
+        total=10,
+        limit=3,
+        offset=0,
+    )
+    assert resp.data == [1, 2, 3]
+    assert resp.total == 10
+    assert resp.limit == 3
+    assert resp.offset == 0
+    assert resp.has_more is True
+
+    # Last page
+    resp_last = PaginatedResponse.create(
+        data=[10],
+        total=10,
+        limit=3,
+        offset=9,
+    )
+    assert resp_last.has_more is False
+
+    # Empty result
+    resp_empty = PaginatedResponse.create(
+        data=[],
+        total=0,
+        limit=10,
+        offset=0,
+    )
+    assert resp_empty.has_more is False
+    assert resp_empty.total == 0
+
+
+def test_search_filters_normalize_repo_and_tags() -> None:
+    """Test SearchFilters normalization of repo and tags."""
+    filters = SearchFilters(
+        repo=["  Acme/App  ", "OWNER/REPO"],
+        tags=["  Auth  ", "auth", "DUPLICATE", "duplicate", ""],
+    )
+    assert filters.repo == ["acme/app", "owner/repo"]
+    assert filters.tags == ["auth", "duplicate"]
+
+    # Empty strings filtered out
+    filters_empty = SearchFilters(repo=["  ", ""], tags=["", "  "])
+    assert filters_empty.repo is None
+    assert filters_empty.tags == []
+
+
+def test_ticket_update_none_fields_preserve_existing() -> None:
+    """Test that TicketUpdate with None fields does not alter existing values."""
+    ts = datetime(2026, 3, 16, 10, 0, 0, tzinfo=UTC)
+    base_data = {
+        "id": "C1",
+        "title": "Original",
+        "repo": "owner/repo",
+        "created_at": ts,
+        "updated_at": ts,
+        "slug": "original",
+    }
+    original = Ticket(**base_data)
+
+    # All-None update should not change anything
+    update = TicketUpdate()
+    update_data = update.model_dump(exclude_unset=True)
+    assert update_data == {}
+
+    # Partial update with explicit Nones
+    partial = TicketUpdate(title=None, description=None, fix=None)
+    unset = partial.model_dump(exclude_unset=True)
+    # Explicitly set fields ARE included even if None
+    assert "title" in unset

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -99,7 +99,7 @@ def store(tmp_path: Path) -> TicketStore:
         ),
     ]
     for ticket in tickets:
-        ticket_store.create(ticket)
+        ticket_store._create(ticket)
     return ticket_store
 
 
@@ -208,7 +208,7 @@ def test_search_ranking(tmp_path: Path) -> None:
         ),
     ]
     for ticket in tickets:
-        store.create(ticket)
+        store._create(ticket)
 
     engine = TicketSearch(store)
     response = engine.search("auth", topk=10)
@@ -275,7 +275,7 @@ def test_special_characters_in_query(store: TicketStore) -> None:
 
 def test_search_with_tokenless_corpus_returns_empty(tmp_path: Path) -> None:
     store = TicketStore(tmp_path / "tickets")
-    store.create(
+    store._create(
         _make_ticket(
             "C1",
             "x",
@@ -323,7 +323,7 @@ def test_search_falls_back_when_bm25_scores_are_non_positive(
 
 def test_search_rebuilds_index_when_ticket_content_changes(tmp_path: Path) -> None:
     store = TicketStore(tmp_path / "tickets")
-    store.create(
+    store._create(
         _make_ticket(
             "C1",
             "Old title",
@@ -401,7 +401,7 @@ def test_search_owner_filter(store: TicketStore) -> None:
         updated_at=datetime(2026, 3, 16, 10, 0, 0, tzinfo=UTC),
         slug="owned-by-alice",
     )
-    store.create(owner_ticket)
+    store._create(owner_ticket)
 
     engine = TicketSearch(store)
     filters = SearchFilters(owner="alice")
@@ -426,12 +426,12 @@ def test_search_has_fix_filter(tmp_path: Path) -> None:
     from vtic.utils import slugify
     s = TicketStore(tmp_path / "tickets")
     now = datetime(2026, 3, 16, 10, 0, 0, tzinfo=UTC)
-    s.create(Ticket(
+    s._create(Ticket(
         id="C1", title="Has fix", description="desc", fix="Apply patch.",
         repo="owner/repo", tags=[], slug=slugify("Has fix"),
         created_at=now, updated_at=now,
     ))
-    s.create(Ticket(
+    s._create(Ticket(
         id="C2", title="No fix", description="desc",
         repo="owner/repo", tags=[], slug=slugify("No fix"),
         created_at=now, updated_at=now,

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -376,3 +376,75 @@ def test_builtin_bm25_empty_corpus_scores_empty() -> None:
     scorer = _BuiltinBM25([])
 
     assert scorer.get_scores(["auth"]) == []
+
+
+def test_search_category_filter(store: TicketStore) -> None:
+    engine = TicketSearch(store)
+    filters = SearchFilters(category=[Category.SECURITY])
+
+    response = engine.search("", filters=filters)
+
+    assert response.total == 2
+    assert all(result.category == Category.SECURITY.value for result in response.results)
+    assert [result.id for result in response.results] == ["S1", "S5"]
+
+
+def test_search_owner_filter(store: TicketStore) -> None:
+    # The store fixture tickets don't have owner set via the helper
+    # Create a ticket with owner directly
+    from datetime import UTC, datetime
+    owner_ticket = Ticket(
+        id="C7", title="Owned by alice", repo="owner/repo",
+        category=Category.CODE_QUALITY, severity=Severity.MEDIUM, status=Status.OPEN,
+        tags=[], owner="alice",
+        created_at=datetime(2026, 3, 16, 10, 0, 0, tzinfo=UTC),
+        updated_at=datetime(2026, 3, 16, 10, 0, 0, tzinfo=UTC),
+        slug="owned-by-alice",
+    )
+    store.create(owner_ticket)
+
+    engine = TicketSearch(store)
+    filters = SearchFilters(owner="alice")
+
+    response = engine.search("", filters=filters)
+
+    assert response.total == 1
+    assert response.results[0].id == "C7"
+
+
+def test_search_tags_filter(store: TicketStore) -> None:
+    engine = TicketSearch(store)
+    filters = SearchFilters(tags=["fastapi"])
+
+    response = engine.search("", filters=filters)
+
+    assert response.total == 1
+    assert response.results[0].id == "S1"
+
+
+def test_search_has_fix_filter(tmp_path: Path) -> None:
+    from vtic.utils import slugify
+    s = TicketStore(tmp_path / "tickets")
+    now = datetime(2026, 3, 16, 10, 0, 0, tzinfo=UTC)
+    s.create(Ticket(
+        id="C1", title="Has fix", description="desc", fix="Apply patch.",
+        repo="owner/repo", tags=[], slug=slugify("Has fix"),
+        created_at=now, updated_at=now,
+    ))
+    s.create(Ticket(
+        id="C2", title="No fix", description="desc",
+        repo="owner/repo", tags=[], slug=slugify("No fix"),
+        created_at=now, updated_at=now,
+    ))
+
+    engine = TicketSearch(s)
+
+    # Tickets with fix
+    response = engine.search("", filters=SearchFilters(has_fix=True))
+    assert response.total == 1
+    assert response.results[0].id == "C1"
+
+    # Tickets without fix
+    response = engine.search("", filters=SearchFilters(has_fix=False))
+    assert response.total == 1
+    assert response.results[0].id == "C2"

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -587,3 +587,79 @@ def test_list_supports_descending_created_at_sort(tmp_path: Path) -> None:
     results = store.list(sort_by="-created_at")
 
     assert [ticket.id for ticket in results] == ["C2", "C1"]
+
+
+def test_list_with_date_filters(tmp_path: Path) -> None:
+    store = TicketStore(tmp_path / "tickets")
+    older = _make_ticket("C1", title="Old ticket")
+    newer = _make_ticket("C2", title="New ticket")
+    between = _make_ticket("C3", title="Between ticket")
+    older = older.model_copy(update={
+        "created_at": datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC),
+        "updated_at": datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC),
+    })
+    between = between.model_copy(update={
+        "created_at": datetime(2026, 3, 1, 0, 0, 0, tzinfo=UTC),
+        "updated_at": datetime(2026, 3, 1, 0, 0, 0, tzinfo=UTC),
+    })
+    newer = newer.model_copy(update={
+        "created_at": datetime(2026, 6, 1, 0, 0, 0, tzinfo=UTC),
+        "updated_at": datetime(2026, 6, 1, 0, 0, 0, tzinfo=UTC),
+    })
+    store.create(older)
+    store.create(between)
+    store.create(newer)
+
+    # created_after
+    results = store.list(SearchFilters(created_after=datetime(2026, 2, 1, 0, 0, 0, tzinfo=UTC)))
+    assert sorted([t.id for t in results]) == ["C2", "C3"]
+
+    # created_before
+    results = store.list(SearchFilters(created_before=datetime(2026, 4, 1, 0, 0, 0, tzinfo=UTC)))
+    assert sorted([t.id for t in results]) == ["C1", "C3"]
+
+    # Range
+    results = store.list(SearchFilters(
+        created_after=datetime(2026, 2, 1, 0, 0, 0, tzinfo=UTC),
+        created_before=datetime(2026, 4, 1, 0, 0, 0, tzinfo=UTC),
+    ))
+    assert [t.id for t in results] == ["C3"]
+
+    # updated_after
+    results = store.list(SearchFilters(updated_after=datetime(2026, 5, 1, 0, 0, 0, tzinfo=UTC)))
+    assert [t.id for t in results] == ["C2"]
+
+
+def test_list_filters_by_severity(tmp_path: Path) -> None:
+    store = TicketStore(tmp_path / "tickets")
+    store.create(_make_ticket("C1", title="Critical", severity=Severity.CRITICAL))
+    store.create(_make_ticket("C2", title="High", severity=Severity.HIGH))
+    store.create(_make_ticket("C3", title="Medium", severity=Severity.MEDIUM))
+    store.create(_make_ticket("C4", title="Low", severity=Severity.LOW))
+
+    # Single severity
+    results = store.list(SearchFilters(severity=[Severity.CRITICAL]))
+    assert [t.id for t in results] == ["C1"]
+
+    # Multiple severities (OR)
+    results = store.list(SearchFilters(severity=[Severity.CRITICAL, Severity.LOW]))
+    assert [t.id for t in results] == ["C1", "C4"]
+
+
+def test_update_changing_repo_moves_file(tmp_path: Path) -> None:
+    """Verify that updating the title with slug change handles file moves correctly."""
+    store = TicketStore(tmp_path / "tickets")
+    ticket = _make_ticket("C1", title="Move me", repo="old/repo")
+    old_path = ticket_path(store.base_dir, ticket)
+    store.create(ticket)
+
+    # TicketUpdate doesn't allow changing repo directly (it's not in the model).
+    # Instead test that updating other fields that change the file path (title/slug) works.
+    updated = store.update("C1", TicketUpdate(title="Moved title"))
+    new_path = ticket_path(store.base_dir, updated)
+
+    assert updated.title == "Moved title"
+    assert not old_path.exists()
+    assert new_path.exists()
+    loaded = store.get("C1")
+    assert loaded.title == "Moved title"

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -70,7 +70,7 @@ def test_create_writes_markdown_file(tmp_path: Path) -> None:
         tags=["refactor", "helpers"],
     )
 
-    store.create(ticket)
+    store._create(ticket)
 
     path = ticket_path(store.base_dir, ticket)
     content = path.read_text(encoding="utf-8")
@@ -88,7 +88,7 @@ def test_create_writes_markdown_file(tmp_path: Path) -> None:
 def test_get_returns_ticket(tmp_path: Path) -> None:
     store = TicketStore(tmp_path / "tickets")
     created = _make_ticket("S1", title="CORS wildcard", category=Category.SECURITY, repo="owner/repo")
-    store.create(created)
+    store._create(created)
 
     loaded = store.get("S1")
 
@@ -106,8 +106,8 @@ def test_list_filters(tmp_path: Path) -> None:
     store = TicketStore(tmp_path / "tickets")
     code_ticket = _make_ticket("C1", title="Code cleanup", category=Category.CODE_QUALITY)
     security_ticket = _make_ticket("S1", title="Fix TLS", category=Category.SECURITY)
-    store.create(code_ticket)
-    store.create(security_ticket)
+    store._create(code_ticket)
+    store._create(security_ticket)
 
     results = store.list(SearchFilters(category=[Category.SECURITY]))
 
@@ -117,7 +117,7 @@ def test_list_filters(tmp_path: Path) -> None:
 def test_update_modifies_file(tmp_path: Path) -> None:
     store = TicketStore(tmp_path / "tickets")
     ticket = _make_ticket("C1", title="Needs fix", status=Status.OPEN)
-    store.create(ticket)
+    store._create(ticket)
 
     updated = store.update("C1", TicketUpdate(status=Status.FIXED))
     content = ticket_path(store.base_dir, updated).read_text(encoding="utf-8")
@@ -130,7 +130,7 @@ def test_delete_removes_file(tmp_path: Path) -> None:
     store = TicketStore(tmp_path / "tickets")
     ticket = _make_ticket("C1", title="Delete me")
     path = ticket_path(store.base_dir, ticket)
-    store.create(ticket)
+    store._create(ticket)
 
     store.delete("C1", force=True)
 
@@ -141,10 +141,10 @@ def test_delete_removes_file(tmp_path: Path) -> None:
 
 def test_concurrent_id_generation(tmp_path: Path) -> None:
     store = TicketStore(tmp_path / "tickets")
-    store.create(_make_ticket("C1", title="Existing cleanup"))
+    store._create(_make_ticket("C1", title="Existing cleanup"))
 
     first = store._next_id(Category.CODE_QUALITY)
-    store.create(_make_ticket(first, title="Queued cleanup"))
+    store._create(_make_ticket(first, title="Queued cleanup"))
     second = store._next_id(Category.CODE_QUALITY)
 
     assert first == "C2"
@@ -219,7 +219,7 @@ def test_create_uses_expected_nested_path(tmp_path: Path) -> None:
     store = TicketStore(tmp_path / "tickets")
     ticket = _make_ticket("S1", title="Nested path", repo="acme/platform", category=Category.SECURITY)
 
-    store.create(ticket)
+    store._create(ticket)
 
     assert ticket_path(store.base_dir, ticket) == (
         tmp_path / "tickets" / "acme" / "platform" / "security" / "S1-nested-path.md"
@@ -252,7 +252,7 @@ def test_create_without_fix_omits_fix_section(tmp_path: Path) -> None:
     store = TicketStore(tmp_path / "tickets")
     ticket = _make_ticket("C1", title="Plain body", description="Only description text.")
 
-    store.create(ticket)
+    store._create(ticket)
 
     content = ticket_path(store.base_dir, ticket).read_text(encoding="utf-8")
     assert "Only description text." in content
@@ -262,7 +262,7 @@ def test_create_without_fix_omits_fix_section(tmp_path: Path) -> None:
 def test_get_is_case_insensitive_for_id_lookup(tmp_path: Path) -> None:
     store = TicketStore(tmp_path / "tickets")
     ticket = _make_ticket("C1", title="Lookup")
-    store.create(ticket)
+    store._create(ticket)
 
     loaded = store.get("c1")
 
@@ -271,9 +271,9 @@ def test_get_is_case_insensitive_for_id_lookup(tmp_path: Path) -> None:
 
 def test_list_returns_sorted_by_ticket_id(tmp_path: Path) -> None:
     store = TicketStore(tmp_path / "tickets")
-    store.create(_make_ticket("S2", title="Second security", category=Category.SECURITY))
-    store.create(_make_ticket("C3", title="Third code"))
-    store.create(_make_ticket("C1", title="First code"))
+    store._create(_make_ticket("S2", title="Second security", category=Category.SECURITY))
+    store._create(_make_ticket("C3", title="Third code"))
+    store._create(_make_ticket("C1", title="First code"))
 
     results = store.list()
 
@@ -283,7 +283,7 @@ def test_list_returns_sorted_by_ticket_id(tmp_path: Path) -> None:
 def test_update_can_change_description_and_fix(tmp_path: Path) -> None:
     store = TicketStore(tmp_path / "tickets")
     ticket = _make_ticket("C1", title="Needs more detail", description="Old", fix=None)
-    store.create(ticket)
+    store._create(ticket)
 
     updated = store.update(
         "C1",
@@ -307,7 +307,7 @@ def test_update_can_clear_nullable_fields(tmp_path: Path) -> None:
         owner="smoke01",
         file="src/app.py:1-2",
     )
-    store.create(ticket)
+    store._create(ticket)
 
     updated = store.update(
         "C1",
@@ -331,7 +331,7 @@ def test_description_preserves_literal_fix_heading(tmp_path: Path) -> None:
         description="Keep this heading:\n## Fix\ninside the description.",
         fix="Actual fix body.",
     )
-    store.create(ticket)
+    store._create(ticket)
 
     loaded = store.get("C1")
 
@@ -343,7 +343,7 @@ def test_update_can_change_category_and_move_file(tmp_path: Path) -> None:
     store = TicketStore(tmp_path / "tickets")
     ticket = _make_ticket("C1", title="Reclassify ticket", category=Category.CODE_QUALITY)
     old_path = ticket_path(store.base_dir, ticket)
-    store.create(ticket)
+    store._create(ticket)
 
     updated = store.update("C1", TicketUpdate(category=Category.SECURITY))
     new_path = ticket_path(store.base_dir, updated)
@@ -357,7 +357,7 @@ def test_update_title_recomputes_slug_and_renames_file(tmp_path: Path) -> None:
     store = TicketStore(tmp_path / "tickets")
     ticket = _make_ticket("C1", title="Original title")
     old_path = ticket_path(store.base_dir, ticket)
-    store.create(ticket)
+    store._create(ticket)
 
     updated = store.update("C1", TicketUpdate(title="Updated auth title"))
     new_path = ticket_path(store.base_dir, updated)
@@ -372,7 +372,7 @@ def test_update_is_atomic(tmp_path: Path) -> None:
     store = TicketStore(tmp_path / "tickets")
     ticket = _make_ticket("C1", title="Original title", category=Category.CODE_QUALITY)
     old_path = ticket_path(store.base_dir, ticket)
-    store.create(ticket)
+    store._create(ticket)
 
     updated = store.update(
         "C1",
@@ -406,10 +406,10 @@ def test_delete_not_found_raises(tmp_path: Path) -> None:
 def test_create_duplicate_id_raises(tmp_path: Path) -> None:
     store = TicketStore(tmp_path / "tickets")
     ticket = _make_ticket("C1", title="Duplicate")
-    store.create(ticket)
+    store._create(ticket)
 
     with pytest.raises(TicketAlreadyExistsError, match="Ticket C1 already exists"):
-        store.create(ticket)
+        store._create(ticket)
 
 
 def test_list_filters_by_repo_status_and_tags(tmp_path: Path) -> None:
@@ -421,10 +421,10 @@ def test_list_filters_by_repo_status_and_tags(tmp_path: Path) -> None:
         status=Status.BLOCKED,
         tags=["auth", "api"],
     )
-    store.create(matching)
-    store.create(_make_ticket("C2", title="Wrong repo", repo="other/app", status=Status.BLOCKED, tags=["auth", "api"]))
-    store.create(_make_ticket("C3", title="Wrong status", repo="acme/app", status=Status.OPEN, tags=["auth", "api"]))
-    store.create(_make_ticket("C4", title="Missing tag", repo="acme/app", status=Status.BLOCKED, tags=["auth"]))
+    store._create(matching)
+    store._create(_make_ticket("C2", title="Wrong repo", repo="other/app", status=Status.BLOCKED, tags=["auth", "api"]))
+    store._create(_make_ticket("C3", title="Wrong status", repo="acme/app", status=Status.OPEN, tags=["auth", "api"]))
+    store._create(_make_ticket("C4", title="Missing tag", repo="acme/app", status=Status.BLOCKED, tags=["auth"]))
 
     results = store.list(
         SearchFilters(
@@ -439,8 +439,8 @@ def test_list_filters_by_repo_status_and_tags(tmp_path: Path) -> None:
 
 def test_list_filters_repo_wildcards(tmp_path: Path) -> None:
     store = TicketStore(tmp_path / "tickets")
-    store.create(_make_ticket("C1", title="Match wildcard", repo="ejacklab/core"))
-    store.create(_make_ticket("C2", title="No match", repo="other/core"))
+    store._create(_make_ticket("C1", title="Match wildcard", repo="ejacklab/core"))
+    store._create(_make_ticket("C2", title="No match", repo="other/core"))
 
     results = store.list(SearchFilters(repo=["ejacklab/*"]))
 
@@ -449,9 +449,9 @@ def test_list_filters_repo_wildcards(tmp_path: Path) -> None:
 
 def test_list_filters_by_has_fix_and_owner(tmp_path: Path) -> None:
     store = TicketStore(tmp_path / "tickets")
-    store.create(_make_ticket("C1", title="Owned fix", owner="smoke01", description="Has a fix", fix="Do it"))
-    store.create(_make_ticket("C2", title="Owned no fix", owner="smoke01", description="No fix", fix=None))
-    store.create(_make_ticket("C3", title="Other owner", owner="alex", description="Other owner", fix="Do it"))
+    store._create(_make_ticket("C1", title="Owned fix", owner="smoke01", description="Has a fix", fix="Do it"))
+    store._create(_make_ticket("C2", title="Owned no fix", owner="smoke01", description="No fix", fix=None))
+    store._create(_make_ticket("C3", title="Other owner", owner="alex", description="Other owner", fix="Do it"))
 
     results = store.list(SearchFilters(has_fix=True, owner="smoke01"))
 
@@ -460,7 +460,7 @@ def test_list_filters_by_has_fix_and_owner(tmp_path: Path) -> None:
 
 def test_list_skips_corrupt_files_and_collects_errors(tmp_path: Path) -> None:
     store = TicketStore(tmp_path / "tickets")
-    store.create(_make_ticket("C1", title="Healthy ticket", repo="acme/app"))
+    store._create(_make_ticket("C1", title="Healthy ticket", repo="acme/app"))
     broken_path = (
         store.base_dir / "acme" / "app" / "code_quality" / "C2-broken-ticket.md"
     )
@@ -478,7 +478,7 @@ def test_soft_delete_moves_file_to_trash(tmp_path: Path) -> None:
     store = TicketStore(tmp_path / "tickets")
     ticket = _make_ticket("C1", title="Trash me", repo="acme/app")
     active_path = ticket_path(store.base_dir, ticket)
-    store.create(ticket)
+    store._create(ticket)
 
     trash_path = store.move_to_trash("C1")
 
@@ -490,7 +490,7 @@ def test_soft_delete_moves_file_to_trash(tmp_path: Path) -> None:
 def test_soft_delete_creates_trash_directory(tmp_path: Path) -> None:
     store = TicketStore(tmp_path / "tickets")
     ticket = _make_ticket("C1", title="Create trash dir")
-    store.create(ticket)
+    store._create(ticket)
 
     store.delete("C1")
 
@@ -500,7 +500,7 @@ def test_soft_delete_creates_trash_directory(tmp_path: Path) -> None:
 def test_force_delete_permanently_removes(tmp_path: Path) -> None:
     store = TicketStore(tmp_path / "tickets")
     ticket = _make_ticket("C1", title="Hard delete")
-    store.create(ticket)
+    store._create(ticket)
 
     store.delete("C1", force=True)
 
@@ -512,7 +512,7 @@ def test_restore_from_trash(tmp_path: Path) -> None:
     store = TicketStore(tmp_path / "tickets")
     ticket = _make_ticket("S1", title="Restore me", category=Category.SECURITY, repo="acme/app")
     original_path = ticket_path(store.base_dir, ticket)
-    store.create(ticket)
+    store._create(ticket)
     store.delete("S1")
 
     restored = store.restore_from_trash("S1")
@@ -526,8 +526,8 @@ def test_list_excludes_trash_directory(tmp_path: Path) -> None:
     store = TicketStore(tmp_path / "tickets")
     active = _make_ticket("C1", title="Active ticket")
     trashed = _make_ticket("C2", title="Trashed ticket")
-    store.create(active)
-    store.create(trashed)
+    store._create(active)
+    store._create(trashed)
     store.delete("C2")
 
     results = store.list()
@@ -538,7 +538,7 @@ def test_list_excludes_trash_directory(tmp_path: Path) -> None:
 def test_find_ticket_excludes_trash_directory(tmp_path: Path) -> None:
     store = TicketStore(tmp_path / "tickets")
     ticket = _make_ticket("C1", title="Hidden in trash")
-    store.create(ticket)
+    store._create(ticket)
     store.delete("C1")
 
     with pytest.raises(TicketNotFoundError):
@@ -554,7 +554,7 @@ def test_soft_delete_preserves_file_content(tmp_path: Path) -> None:
         fix="Original fix.",
         tags=["alpha", "beta"],
     )
-    store.create(ticket)
+    store._create(ticket)
     original_content = ticket_path(store.base_dir, ticket).read_text(encoding="utf-8")
 
     trash_path = store.move_to_trash("C1")
@@ -564,9 +564,9 @@ def test_soft_delete_preserves_file_content(tmp_path: Path) -> None:
 
 def test_list_supports_sort_by_severity(tmp_path: Path) -> None:
     store = TicketStore(tmp_path / "tickets")
-    store.create(_make_ticket("C1", title="Medium priority", severity=Severity.MEDIUM))
-    store.create(_make_ticket("C2", title="Critical priority", severity=Severity.CRITICAL))
-    store.create(_make_ticket("C3", title="Low priority", severity=Severity.LOW))
+    store._create(_make_ticket("C1", title="Medium priority", severity=Severity.MEDIUM))
+    store._create(_make_ticket("C2", title="Critical priority", severity=Severity.CRITICAL))
+    store._create(_make_ticket("C3", title="Low priority", severity=Severity.LOW))
 
     results = store.list(sort_by="severity")
 
@@ -581,8 +581,8 @@ def test_list_supports_descending_created_at_sort(tmp_path: Path) -> None:
     newer_timestamp = datetime(2026, 3, 16, 11, 0, 0, tzinfo=UTC)
     older = older.model_copy(update={"created_at": older_timestamp, "updated_at": older_timestamp})
     newer = newer.model_copy(update={"created_at": newer_timestamp, "updated_at": newer_timestamp})
-    store.create(older)
-    store.create(newer)
+    store._create(older)
+    store._create(newer)
 
     results = store.list(sort_by="-created_at")
 
@@ -606,9 +606,9 @@ def test_list_with_date_filters(tmp_path: Path) -> None:
         "created_at": datetime(2026, 6, 1, 0, 0, 0, tzinfo=UTC),
         "updated_at": datetime(2026, 6, 1, 0, 0, 0, tzinfo=UTC),
     })
-    store.create(older)
-    store.create(between)
-    store.create(newer)
+    store._create(older)
+    store._create(between)
+    store._create(newer)
 
     # created_after
     results = store.list(SearchFilters(created_after=datetime(2026, 2, 1, 0, 0, 0, tzinfo=UTC)))
@@ -632,10 +632,10 @@ def test_list_with_date_filters(tmp_path: Path) -> None:
 
 def test_list_filters_by_severity(tmp_path: Path) -> None:
     store = TicketStore(tmp_path / "tickets")
-    store.create(_make_ticket("C1", title="Critical", severity=Severity.CRITICAL))
-    store.create(_make_ticket("C2", title="High", severity=Severity.HIGH))
-    store.create(_make_ticket("C3", title="Medium", severity=Severity.MEDIUM))
-    store.create(_make_ticket("C4", title="Low", severity=Severity.LOW))
+    store._create(_make_ticket("C1", title="Critical", severity=Severity.CRITICAL))
+    store._create(_make_ticket("C2", title="High", severity=Severity.HIGH))
+    store._create(_make_ticket("C3", title="Medium", severity=Severity.MEDIUM))
+    store._create(_make_ticket("C4", title="Low", severity=Severity.LOW))
 
     # Single severity
     results = store.list(SearchFilters(severity=[Severity.CRITICAL]))
@@ -651,7 +651,7 @@ def test_update_changing_repo_moves_file(tmp_path: Path) -> None:
     store = TicketStore(tmp_path / "tickets")
     ticket = _make_ticket("C1", title="Move me", repo="old/repo")
     old_path = ticket_path(store.base_dir, ticket)
-    store.create(ticket)
+    store._create(ticket)
 
     # TicketUpdate doesn't allow changing repo directly (it's not in the model).
     # Instead test that updating other fields that change the file path (title/slug) works.


### PR DESCRIPTION
Implements the core ticket lifecycle use case:
- Ticket data models (Severity, Status, Category enums, Ticket dataclass)
- Markdown file storage (create, read, update, delete tickets as .md files)
- CLI commands (init, create, get, list, update, delete, search, serve)
- BM25 keyword search with filters
- FastAPI HTTP API server
- Comprehensive test suite (159 tests)

Built with: Typer, Pydantic, FastAPI, Rich, Zvec